### PR TITLE
Enable private model download from Hugging Face Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget \
 
 RUN python -m pip install --upgrade pip
 RUN python -m pip --no-cache-dir install fairseq@git+https://github.com//pytorch/fairseq.git@f2146bdc7abf293186de9449bfa2272775e39e1d#egg=fairseq
-# TODO: Update URL if we merge back to s3prl repository
-RUN python -m pip --no-cache-dir install git+https://github.com/huggingface/s3prl.git@huggingface2#egg=s3prl
+RUN python -m pip --no-cache-dir install git+https://github.com/s3prl/s3prl.git#egg=s3prl
 
 COPY s3prl/ /app/s3prl
 COPY src/ /app/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ RUN git config --global user.name "SUPERB Admin"
 ENV upstream_model osanseviero/hubert_base
 ENV downstream_task asr
 ENV hub huggingface
+ENV hf_hub_org None
 ENV push_to_hf_hub True
 ENV override None
 
 WORKDIR /app/s3prl
 # Each task's config.yaml is used to set all the training parameters, but can be overridden with the `override` argument
 # The results of each training run are stored in /app/s3prl/result/downstream/{downstream_task}
-# and pushed to the Hugging Face Hub with name {hf_username}/superb-s3prl-{upstream_model}-{downstream_task}-uuid
-CMD python run_downstream.py -n ${downstream_task} -m train -u ${upstream_model} -d ${downstream_task} --hub ${hub} --push_to_hf_hub ${push_to_hf_hub} --override ${override}
+# and pushed to the Hugging Face Hub with name {hf_hub_org}/superb-s3prl-{upstream_model}-{downstream_task}-uuid
+CMD python run_downstream.py -n ${downstream_task} -m train -u ${upstream_model} -d ${downstream_task} --hub ${hub} --hf_hub_org ${hf_hub_org} --push_to_hf_hub ${push_to_hf_hub} --override ${override}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,7 @@ ENV override None
 WORKDIR /app/s3prl
 # Each task's config.yaml is used to set all the training parameters, but can be overridden with the `override` argument
 # The results of each training run are stored in /app/s3prl/result/downstream/{downstream_task}
-# and pushed to the Hugging Face Hub with name {hf_hub_org}/superb-s3prl-{upstream_model}-{downstream_task}-uuid
+# and pushed to the Hugging Face Hub with name: 
+#   Default behaviour   - {hf_hub_username}/superb-s3prl-{upstream_model}-{downstream_task}-uuid
+#   With hf_hub_org set - {hf_hub_org}/superb-s3prl-{upstream_model}-{downstream_task}-uuid
 CMD python run_downstream.py -n ${downstream_task} -m train -u ${upstream_model} -d ${downstream_task} --hub ${hub} --hf_hub_org ${hf_hub_org} --push_to_hf_hub ${push_to_hf_hub} --override ${override}

--- a/s3prl/downstream/README.md
+++ b/s3prl/downstream/README.md
@@ -35,11 +35,12 @@ All of the downstream task follow the following command pattern, with a few task
 ```bash
 cd s3prl/
 
-# general pattern
+# General pattern
 python3 run_downstream.py -m train -n ExpName -u UpstreamName -d DownstreamName
-# an example with pulling / pushing models via the Hugging Face Hub
+# An example with downloading / uploading models via the Hugging Face Hub.
+# Use the credentials associated with your account on huggingface.co
 HF_USERNAME=username HF_PASSWORD=password python3 run_downstream.py -m train -n ExpName -u UpstreamName -d DownstreamName --hub huggingface --push_to_hf_hub True
-# a directly runnable example without data preparation
+# A directly runnable example without data preparation
 python3 run_downstream.py -m train -n ExpName -u fbank -d example
 ```
 

--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -432,7 +432,7 @@ class Runner():
             self.downstream.model.inference(features, [filename])
 
     def push_to_huggingface_hub(self):
-        if self.args.hf_hub_org:
+        if self.args.hf_hub_org.lower() != "none":
             organization = self.args.hf_hub_org
         else:
             organization = os.environ.get("HF_USERNAME")

--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -78,8 +78,14 @@ class Runner():
         if "from_hf_hub" in self.args and self.args.from_hf_hub == True:
             from huggingface_hub import snapshot_download
 
+            # Setup auth
+            hf_user = os.environ.get("HF_USERNAME")
+            hf_password = os.environ.get("HF_PASSWORD")
+            huggingface_token = HfApi().login(username=hf_user, password=hf_password)
+            HfFolder.save_token(huggingface_token)
+
             print(f'Downloading upstream model {self.args.upstream} from the Hugging Face Hub')
-            filepath = snapshot_download(self.args.upstream)
+            filepath = snapshot_download(self.args.upstream, use_auth_token=True)
             sys.path.append(filepath)
 
             from expert import UpstreamExpert

--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -452,7 +452,8 @@ class Runner():
         print(f"Created Hub repo: {repo_url}")
 
         # Download repo and copy templates
-        REPO_PATH = self.args.expdir + "/hub_repo/"
+        REPO_PATH = os.path.join(self.args.expdir, "hf_hub_repos", repo_name)
+        print(REPO_PATH)
         model_repo = Repository(
             local_dir=REPO_PATH, clone_from=repo_url, use_auth_token=huggingface_token
         )

--- a/s3prl/run_downstream.py
+++ b/s3prl/run_downstream.py
@@ -17,6 +17,7 @@ from s3prl import downstream
 from s3prl.downstream.runner import Runner
 from s3prl.utility.helper import backup, get_time_tag, hack_isinstance, is_leader_process, override
 
+from huggingface_hub import HfApi, HfFolder
 
 def get_downstream_args():
     parser = argparse.ArgumentParser()
@@ -73,6 +74,7 @@ def get_downstream_args():
     parser.add_argument('-p', '--expdir', help='Save experiment at expdir')
     parser.add_argument('-a', '--auto_resume', action='store_true', help='Auto-resume if the expdir contains checkpoints')
     parser.add_argument('--push_to_hf_hub', default=False, help='Push all files in experiment directory to the Hugging Face Hub. To use this feature you must set HF_USERNAME and HF_PASSWORD as environment variables in your shell')
+    parser.add_argument('--hf_hub_org', help='The Hugging Face Hub organisation to push fine-tuned models to')
 
     # options
     parser.add_argument('--seed', default=1337, type=int)
@@ -174,6 +176,12 @@ def main():
 
     if args.hub == "huggingface":
         args.from_hf_hub = True
+        # Setup auth
+        hf_user = os.environ.get("HF_USERNAME")
+        hf_password = os.environ.get("HF_PASSWORD")
+        huggingface_token = HfApi().login(username=hf_user, password=hf_password)
+        HfFolder.save_token(huggingface_token)
+        print(f"Logged into Hugging Face Hub with user: {hf_user}")
     
     # Save command
     if is_leader_process():

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ requirements = [
     "editdistance",
     "easydict",
     "catalyst",
-    "huggingface-hub>=0.0.17"
+    "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git#egg=huggingface_hub" # TODO: Replace with v0.0.17 when it is released
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ requirements = [
     "editdistance",
     "easydict",
     "catalyst",
+    "huggingface-hub>=0.0.17"
 ]
 
 # Arguments marked as "Required" below must be included for upload to PyPI.


### PR DESCRIPTION
This PR allows `s3prl` users to download _private_ upstream models from the Hugging Face Hub. I also took the liberty of updating the Git URL to install `s3prl` in the Dockerfile.

Note that the fine-tuned models are pushed to the HF Hub user profile by default, so I've included a flag that allows us to push all the fine-tuned models to a single organisation like [SUPERB](https://huggingface.co/superb)

Example:

* Private pretrained model (only @leo19941227 can see this): https://huggingface.co/superb-test-org/test-submission-with-weights
* Private fine-tuned model (only SUPERB members can see this): https://huggingface.co/superb/superb-s3prl-superb-test-org__test-submission-with-weights-asr-b897c4e0

```bash
# Here we pull from one org and push to SUPERB
python3 run_downstream.py -n asr-push-to-hub -m train -u superb-test-org/test-submission-with-weights -d asr --hub huggingface --push_to_hf_hub True --hf_hub_org superb -o "config.downstream_expert.datarc.libri_root='/data/lewis/superb/LibriSpeech',,config.downstream_expert.datarc.bucket_file='/data/lewis/superb/LibriSpeech/len_for_bucket',,config.runner.total_steps=10,,config.runner.save_step=5"
```

TODO:

- [x] Refactor authentication to do it once instead of twice
- [x] Enable fine-tuned models to be pushed to organisation?