### PR TITLE
Upstream explicitly provide downsample rate to enable random stride

### DIFF
--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -107,6 +107,7 @@ class Runner():
             model = model,
             name = 'Upstream',
             trainable = self.args.upstream_trainable,
+            interfaces = ["get_downsample_rates"]
         )
 
 

--- a/s3prl/upstream/apc/expert.py
+++ b/s3prl/upstream/apc/expert.py
@@ -43,6 +43,9 @@ class UpstreamExpert(UpstreamBase):
             )
             self.add_hook("self.model", lambda input, output: output[1])
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         features = [self.preprocessor(wav.unsqueeze(0)) for wav in wavs]
         feat_lengths = [len(feat) for feat in features]
@@ -53,4 +56,6 @@ class UpstreamExpert(UpstreamBase):
         predicted_BxLxM, features = self.model(
             features, feat_lengths, testing=not self.training
         )
-        return {"default": features}
+
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/byol_a/expert.py
+++ b/s3prl/upstream/byol_a/expert.py
@@ -64,7 +64,7 @@ class UpstreamExpert(nn.Module):
         return self.output_dim
 
     # Interface
-    def get_downsample_rate(self):
+    def get_downsample_rates(self, key: str) -> int:
         return 15344.655344655344 # computed by: len(wavs[0]) / len(features[0]) * self.max_input_length
 
     # forward in chunks

--- a/s3prl/upstream/cpc/expert.py
+++ b/s3prl/upstream/cpc/expert.py
@@ -42,9 +42,12 @@ class UpstreamExpert(UpstreamBase):
             )
             self.add_hook("self.model.gAR", lambda input, output: output)
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         padded_wav = pad_sequence(wavs, batch_first=True)
         features = self.model(padded_wav.unsqueeze(1), None)[0]
-        return {
-            "default": features,
-        }
+
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/decoar/expert.py
+++ b/s3prl/upstream/decoar/expert.py
@@ -34,6 +34,9 @@ class UpstreamExpert(nn.Module):
 
         self.output_dim = 2048
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         """
         Args:
@@ -65,4 +68,5 @@ class UpstreamExpert(nn.Module):
 
         features = self.model(features, padding_mask)
 
-        return {"default": features}
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/decoar2/expert.py
+++ b/s3prl/upstream/decoar2/expert.py
@@ -44,6 +44,9 @@ class UpstreamExpert(UpstreamBase):
                 )
             self.add_hook("self.model.encoder", lambda input, output: output[0])
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         """
         Args:
@@ -75,4 +78,5 @@ class UpstreamExpert(UpstreamBase):
 
         features, layer_results = self.model(features, padding_mask)
 
-        return {"default": features}
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/hubert/expert.py
+++ b/s3prl/upstream/hubert/expert.py
@@ -54,6 +54,9 @@ class UpstreamExpert(UpstreamBase):
                 )
             self.add_hook("self.model.encoder", lambda input, output: output[0])
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 320
+
     def forward(self, wavs):
         if self.task.cfg.normalize:
             wavs = [F.layer_norm(wav, wav.shape) for wav in wavs]
@@ -71,6 +74,6 @@ class UpstreamExpert(UpstreamBase):
             padding_mask=wav_padding_mask,
             mask=None,
         )
-        return {
-            "default": features,
-        }
+
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/interfaces.py
+++ b/s3prl/upstream/interfaces.py
@@ -179,6 +179,10 @@ class Featurizer(nn.Module):
         self.output_dim = feature.size(-1)
         if hasattr(upstream, "get_downsample_rates"):
             self.downsample_rate = upstream.get_downsample_rates(feature_selection)
+            show(
+                f"[{self.name}] - The selected feature {feature_selection}'s downsample rate is {self.downsample_rate}",
+                file=sys.stderr
+            )
         else:
             self.downsample_rate = round(max(len(wav) for wav in paired_wavs) / feature.size(1))
             show(

--- a/s3prl/upstream/interfaces.py
+++ b/s3prl/upstream/interfaces.py
@@ -96,16 +96,6 @@ class UpstreamBase(nn.Module, metaclass=initHook):
             generate_hook_handler(self._hook_hiddens, hook)
         )
 
-    @staticmethod
-    def tolist(paired_wavs: List[Tensor], paired_feature: Tensor):
-        assert paired_feature.dim() == 3
-        # (batch_size, max_seq_len, feat_dim)
-
-        ratio = max([len(wav) for wav in paired_wavs]) / paired_feature.size(1)
-        feature_len = [round(len(wav) / ratio) for wav in paired_wavs]
-        feature = [f[:l] for f, l in zip(paired_feature, feature_len)]
-        return feature
-
     def __call__(self, wavs: List[Tensor], *args, **kwargs):
         self._hook_hiddens.clear()
 
@@ -137,10 +127,6 @@ class UpstreamBase(nn.Module, metaclass=initHook):
             for layer_id, hidden_state in enumerate(result["hidden_states"]):
                 result[f"hidden_state_{layer_id}"] = hidden_state
 
-            default = result.get("default")
-            if default is not None:
-                assert torch.allclose(default, result["last_hidden_state"])
-
         return result
 
 
@@ -153,25 +139,37 @@ class Featurizer(nn.Module):
         **kwargs,
     ):
         super().__init__()
-        self.feature_selection = feature_selection
-        self.name = f"Featurizer for {upstream.__class__}"
+        self.name = "Featurizer"
 
-        show(
-            f"[{self.name}] - The input upstream is only for initialization and not saved in this nn.Module"
-        )
-
-        # This line is necessary as some models behave differently between train/eval
-        # eg. The LayerDrop technique used in wav2vec2
         upstream.eval()
-
         paired_wavs = [torch.randn(SAMPLE_RATE).to(upstream_device)]
-        paired_features = upstream(paired_wavs)
+        with torch.no_grad():
+            paired_features = upstream(paired_wavs)
+
+        if feature_selection not in paired_features:
+            if "hidden_states" in paired_features:
+                show(
+                    f"[{self.name}] - Warning: {feature_selection} is not a supported args.upstream_feature_selection."
+                    f" Using \"hidden_states\" as the default key.",
+                    file=sys.stderr
+                )
+                feature_selection = "hidden_states"
+            else:
+                show(
+                    f"[{self.name}] - Error: {feature_selection} is not a supported args.upstream_feature_selection."
+                    f" The default key \"hidden_states\" is also not supported."
+                    f" Please specify -s with the following options: {list(paired_wavs.keys())}",
+                    file=sys.stderr
+                )
+                raise ValueError
+        self.feature_selection = feature_selection
 
         feature = self._select_feature(paired_features)
         if isinstance(feature, (list, tuple)):
             self.layer_num = len(feature)
             show(
-                f"[{self.name}] - Take a list of {self.layer_num} features and weighted sum them."
+                f"[{self.name}] - Take a list of {self.layer_num} features and weighted sum them.",
+                file=sys.stderr
             )
             self.weights = nn.Parameter(torch.zeros(self.layer_num))
             feature = self._weighted_sum([f.cpu() for f in feature])
@@ -179,11 +177,17 @@ class Featurizer(nn.Module):
             feature = feature.cpu()
 
         self.output_dim = feature.size(-1)
-        ratio = round(max(len(wav) for wav in paired_wavs) / feature.size(1))
-        possible_rate = torch.LongTensor([160, 320])
-        self.downsample_rate = int(
-            possible_rate[(possible_rate - ratio).abs().argmin(dim=-1)]
-        )
+        if hasattr(upstream, "get_downsample_rates"):
+            self.downsample_rate = upstream.get_downsample_rates(feature_selection)
+        else:
+            self.downsample_rate = round(max(len(wav) for wav in paired_wavs) / feature.size(1))
+            show(
+                f"[{self.name}] - Warning: The provided upstream does not give statis downsample rate"
+                " by the \"get_downsample_rates\" interface (see upstream/example/expert.py)."
+                " The downsample rate is calculated dynamically basing on the shape of the"
+                f" input waveforms v.s. the output features: {self.downsample_rate}",
+                file=sys.stderr
+            )
 
     def _select_feature(self, features):
         feature = features.get(self.feature_selection)
@@ -194,17 +198,6 @@ class Featurizer(nn.Module):
         if isinstance(feature, (list, tuple)) and len(feature) == 1:
             feature = feature[0]
 
-        if feature is None:
-            available_options = [key for key in features.keys() if key[0] != "_"]
-            show(
-                f"[{self.name}] - feature_selection = {self.feature_selection} is not supported for this upstream.",
-                file=sys.stderr,
-            )
-            show(
-                f"[{self.name}] - Supported options: {available_options}",
-                file=sys.stderr,
-            )
-            raise ValueError
         return feature
 
     def _weighted_sum(self, feature):
@@ -235,6 +228,12 @@ class Featurizer(nn.Module):
 
         return weighted_feature
 
+    def tolist(self, paired_wavs: List[Tensor], paired_feature: Tensor):
+        assert paired_feature.dim() == 3, "(batch_size, max_seq_len, feat_dim)"
+        feature_len = [round(len(wav) / self.downsample_rate) for wav in paired_wavs]
+        feature = [f[:l] for f, l in zip(paired_feature, feature_len)]
+        return feature
+
     def forward(
         self,
         paired_wavs: List[Tensor],
@@ -244,4 +243,4 @@ class Featurizer(nn.Module):
         if isinstance(feature, (list, tuple)):
             feature = self._weighted_sum(feature)
 
-        return UpstreamBase.tolist(paired_wavs, feature)
+        return self.tolist(paired_wavs, feature)

--- a/s3prl/upstream/log_stft/expert.py
+++ b/s3prl/upstream/log_stft/expert.py
@@ -76,6 +76,9 @@ class UpstreamExpert(nn.Module):
         self.output_dim = self.extracter.get_output_dim()
         self.downsample_rate = self.extracter.get_downsample_rate()
 
+    def get_downsample_rates(self, key: str) -> int:
+        return self.downsample_rate
+
     def _extractor_forward(self, wavs):
         feats = []
         for wav in wavs:

--- a/s3prl/upstream/mockingjay/expert.py
+++ b/s3prl/upstream/mockingjay/expert.py
@@ -53,6 +53,8 @@ class UpstreamExpert(UpstreamBase):
             self.transformer, "extracter"
         ), "This wrapper only supports `on-the-fly` ckpt with built in feature extracters."
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
 
     def forward(self, wavs):
         last_hidden_state, hidden_states = self.transformer(wavs)  # (batch_size, extracted_seqlen, feature_dim)

--- a/s3prl/upstream/npc/expert.py
+++ b/s3prl/upstream/npc/expert.py
@@ -40,9 +40,14 @@ class UpstreamExpert(UpstreamBase):
 
             self.add_hook("self.model", lambda input, output: output[1])
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         features = [self.preprocessor(wav.unsqueeze(0)) for wav in wavs]
         features = pad_sequence(features, batch_first=True)
 
         predicted_BxLxM, features = self.model(features, testing=not self.training)
-        return {"default": features}
+
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/pase/expert.py
+++ b/s3prl/upstream/pase/expert.py
@@ -24,6 +24,9 @@ class UpstreamExpert(UpstreamBase):
 
         self.model = build_pase(ckpt, model_config)
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         wavs = pad_sequence(wavs, batch_first=True)
         wavs = wavs.unsqueeze(1)
@@ -33,4 +36,5 @@ class UpstreamExpert(UpstreamBase):
             1, 2
         ).contiguous()  # (batch_size, extracted_seqlen, feature_dim)
 
-        return {"default": features}
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/roberta/expert.py
+++ b/s3prl/upstream/roberta/expert.py
@@ -51,4 +51,5 @@ class UpstreamExpert(UpstreamBase):
         ).to(wavs[0].device)
         features = self.roberta.extract_features(tokens)
 
-        return {"default": features}
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/wav2vec/expert.py
+++ b/s3prl/upstream/wav2vec/expert.py
@@ -60,6 +60,9 @@ class UpstreamExpert(UpstreamBase):
                     lambda input, output: input[0].transpose(1, 2),
                 )
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 160
+
     def forward(self, wavs):
         """
         Code snippet modified from fairseq
@@ -82,6 +85,7 @@ class UpstreamExpert(UpstreamBase):
         result["c"] = x.transpose(1, 2).contiguous()
         result["default"] = result["c"]
 
+        # The keys "hidden_states" and "last_hidden_state" are handled by UpstreamBase's hooks
         return result
 
 

--- a/s3prl/upstream/wav2vec2/expert.py
+++ b/s3prl/upstream/wav2vec2/expert.py
@@ -46,6 +46,9 @@ class UpstreamExpert(UpstreamBase):
                 )
             self.add_hook("self.model.encoder", lambda input, output: output[0])
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 320
+
     def forward(self, wavs):
         device = wavs[0].device
         if self.wav_normalize:
@@ -65,4 +68,6 @@ class UpstreamExpert(UpstreamBase):
         results = self.model.extract_features(
             padded_wav, wav_padding_mask if self.apply_padding_mask else None
         )
-        return {"default": results["x"]}
+
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks


### PR DESCRIPTION
The existing SSL pretraining methods are all in 10ms or 20ms stride, which makes the original implementation: `calculating stride dynamically` easy and convenient.
However, this will not be sufficient for the SUPERB Challenge, where people can submit upstreams in ANY stride.
The benchmark framework should be generic and can benchmark any possible stride.

This PR only upgrades upstream experts to have the `get_downsample_rates` interface function, and also upgrade `Featurizer` for it to consider the static/fixed downsample rate provided by the upstream instead of calculating it basing on the waveform/representation pair. (If the upstream do not provide the `get_downsample_rates` then it will degenerate back to compute the downsample rate dynamically)

The next PR will upgrade SD to align the labels with upstream's downsample rate automatically.