### PR TITLE
SD auto-align any stride without changing config & scoring script

### DIFF
--- a/s3prl/downstream/diarization/config.yaml
+++ b/s3prl/downstream/diarization/config.yaml
@@ -18,7 +18,6 @@ optimizer:
 downstream_expert:
   datarc:
     chunk_size: 2000
-    frame_shift: 160 # this should be aligned with upstrema model
     subsampling: 1
     label_delay: 0
     num_speakers: 2

--- a/s3prl/downstream/diarization/expert.py
+++ b/s3prl/downstream/diarization/expert.py
@@ -42,6 +42,11 @@ class DownstreamExpert(nn.Module):
         self.upstream_dim = upstream_dim
         self.upstream_rate = upstream_rate
         self.datarc = downstream_expert["datarc"]
+        self.datarc["frame_shift"] = upstream_rate
+
+        with (Path(expdir) / "upstream_rate").open("w") as file:
+            print(upstream_rate, file=file)
+
         self.loaderrc = downstream_expert["loaderrc"]
         self.modelrc = downstream_expert["modelrc"]
         self.scorerc = downstream_expert["scorerc"]

--- a/s3prl/downstream/diarization/score.sh
+++ b/s3prl/downstream/diarization/score.sh
@@ -22,7 +22,12 @@ test_set="$2"
 # directory where you cloned dscore (https://github.com/ftshijt/dscore)
 dscore_dir=/groups/leo1994122701/dscore
 
-frame_shift=160
+upstream_rate_file=$1/upstream_rate
+if [ -f $upstream_rate_file ]; then
+    frame_shift=$(cat $upstream_rate_file)
+else
+    frame_shift=160
+fi
 sr=16000
 
 echo "scoring at $scoring_dir"


### PR DESCRIPTION
Hey @ftshijt !

I make a little change to let the SD downstream expert automatically use the stride information from upstream.
Also, by saving this information into expdir, the user don't need to take care of different upstream stride when scoring.
Could you please help me review if my change is correct and sufficient for SD to benchmark any stride?

Many thanks!!