### PR TITLE
Get dataloader with epoch

### DIFF
--- a/s3prl/downstream/example/dataset.py
+++ b/s3prl/downstream/example/dataset.py
@@ -7,7 +7,7 @@ from torch.utils.data.dataset import Dataset
 SAMPLE_RATE = 16000
 EXAMPLE_WAV_MIN_SEC = 5
 EXAMPLE_WAV_MAX_SEC = 20
-EXAMPLE_DATASET_SIZE = 1000
+EXAMPLE_DATASET_SIZE = 200
 
 
 class RandomDataset(Dataset):

--- a/s3prl/downstream/example/expert.py
+++ b/s3prl/downstream/example/expert.py
@@ -65,7 +65,7 @@ class DownstreamExpert(nn.Module):
         self.register_buffer('best_score', torch.zeros(1))
 
     # Interface
-    def get_dataloader(self, split):
+    def get_dataloader(self, split, epoch: int = 0):
         """
         Args:
             split: string
@@ -89,15 +89,17 @@ class DownstreamExpert(nn.Module):
         """
 
         if split == 'train':
-            return self._get_train_dataloader(self.train_dataset)            
+            return self._get_train_dataloader(self.train_dataset, epoch)
         elif split == 'dev':
             return self._get_eval_dataloader(self.dev_dataset)
         elif split == 'test':
             return self._get_eval_dataloader(self.test_dataset)
 
 
-    def _get_train_dataloader(self, dataset):
+    def _get_train_dataloader(self, dataset, epoch: int):
         sampler = DistributedSampler(dataset) if is_initialized() else None
+        if sampler is not None:
+            sampler.set_epoch(epoch)
         return DataLoader(
             dataset, batch_size=self.datarc['train_batch_size'],
             shuffle=(sampler is None),

--- a/s3prl/downstream/example/expert.py
+++ b/s3prl/downstream/example/expert.py
@@ -97,9 +97,8 @@ class DownstreamExpert(nn.Module):
 
 
     def _get_train_dataloader(self, dataset, epoch: int):
-        sampler = DistributedSampler(dataset) if is_initialized() else None
-        if sampler is not None:
-            sampler.set_epoch(epoch)
+        from s3prl.utility.data import get_ddp_sampler
+        sampler = get_ddp_sampler(dataset, epoch)
         return DataLoader(
             dataset, batch_size=self.datarc['train_batch_size'],
             shuffle=(sampler is None),

--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -199,17 +199,13 @@ class Runner():
         if is_leader_process():
             logger = SummaryWriter(self.args.expdir)
 
-        # prepare data
-        dataloader = self.downstream.model.get_dataloader('train')
-
         batch_ids = []
         backward_steps = 0
         records = defaultdict(list)
         epoch = self.init_ckpt.get('Epoch', 0)
+        train_split = self.config['runner'].get("train_dataloader", "train")
         while pbar.n < pbar.total:
-            if is_initialized():
-                dataloader.sampler.set_epoch(epoch)
-
+            dataloader = self.downstream.model.get_dataloader(train_split, epoch=epoch)
             for batch_id, (wavs, *others) in enumerate(tqdm(dataloader, dynamic_ncols=True, desc='train', file=tqdm_file)):
                 # try/except block for forward/backward
                 try:
@@ -229,7 +225,7 @@ class Runner():
                         features, _ = specaug(features)
 
                     loss = self.downstream.model(
-                        'train',
+                        train_split,
                         features, *others,
                         records = records,
                     )
@@ -279,7 +275,7 @@ class Runner():
                 # logging
                 if global_step % self.config['runner']['log_step'] == 0:
                     self.downstream.model.log_records(
-                        'train',
+                        train_split,
                         records = records,
                         logger = logger,
                         global_step = global_step,

--- a/s3prl/utility/data.py
+++ b/s3prl/utility/data.py
@@ -1,0 +1,14 @@
+from torch.distributed.distributed_c10d import is_initialized
+from torch.utils.data import Dataset, DistributedSampler
+
+def get_ddp_sampler(dataset: Dataset, epoch: int):
+    """
+    This function will create a DistributedSampler if DDP is initialized,
+    and will just return None if DDP is not initialized.
+    """
+    if is_initialized():
+        sampler = DistributedSampler(dataset)
+        sampler.set_epoch(epoch)
+    else:
+        sampler = None
+    return sampler


### PR DESCRIPTION
The dataloader involve sampler, which sometimes need the epoch information, eg. DistributedSampler.
Hence it will be more generic to pass the epoch into the `get_dataloader` of downstream expert.
Note that this interface upgrade is backward compatible with the original interface, where if the downstream expert does not accept the epoch argument, will degenerate back to NOT giving epoch argument.
So all the existing downstream implementations are automatically supported.