### PR TITLE
Add Unispeech-SAT upstream models and Wavlm-Large download link

### DIFF
--- a/s3prl/upstream/unispeech_sat/expert.py
+++ b/s3prl/upstream/unispeech_sat/expert.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# -*- coding: utf-8 -*- #
+"""*********************************************************************************************"""
+#   FileName     [ upstream/unispeech_sat/expert.py ]
+#   Synopsis     [ the UniSpeech-SAT wrapper ]
+#   Author       [ Microsoft ]
+"""*********************************************************************************************"""
+
+
+###############
+# IMPORTATION #
+###############
+
+import torch
+import torch.nn.functional as F
+from torch.nn.utils.rnn import pad_sequence
+
+from ..wavlm.WavLM import WavLM, WavLMConfig
+from ..interfaces import UpstreamBase
+
+
+############
+# CONSTANT #
+############
+SAMPLE_RATE = 16000
+EXAMPLE_SEC = 5
+
+
+###################
+# UPSTREAM EXPERT #
+###################
+class UpstreamExpert(UpstreamBase):
+    def __init__(self, ckpt, **kwargs):
+        super().__init__(**kwargs)
+
+        checkpoint = torch.load(ckpt)
+        self.cfg = WavLMConfig(checkpoint['cfg'])
+        self.model = WavLM(self.cfg)
+        self.model.load_state_dict(checkpoint['model'])
+
+        if len(self.hooks) == 0:
+            module_name = "self.model.encoder.layers"
+            for module_id in range(len(eval(module_name))):
+                self.add_hook(
+                    f"{module_name}[{module_id}]",
+                    lambda input, output: input[0].transpose(0, 1),
+                )
+            self.add_hook("self.model.encoder", lambda input, output: output[0])
+
+    def get_downsample_rates(self, key: str) -> int:
+        return 320
+
+    def forward(self, wavs):
+        if self.cfg.normalize:
+            wavs = [F.layer_norm(wav, wav.shape) for wav in wavs]
+
+        device = wavs[0].device
+        wav_lengths = torch.LongTensor([len(wav) for wav in wavs]).to(device)
+        wav_padding_mask = ~torch.lt(
+            torch.arange(max(wav_lengths)).unsqueeze(0).to(device),
+            wav_lengths.unsqueeze(1),
+        )
+        padded_wav = pad_sequence(wavs, batch_first=True)
+
+        features, feat_padding_mask = self.model.extract_features(
+            padded_wav,
+            padding_mask=wav_padding_mask,
+            mask=False,
+        )
+
+        # This forward function only does the model forward
+        # The return dict is then handled by UpstreamBase's hooks

--- a/s3prl/upstream/unispeech_sat/hubconf.py
+++ b/s3prl/upstream/unispeech_sat/hubconf.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# -*- coding: utf-8 -*- #
+"""*********************************************************************************************"""
+#   FileName     [ upstream/unispeech_sat/hubconf.py ]
+#   Synopsis     [ the UniSpeech-SAT torch hubconf ]
+#   Author       [ Microsoft ]
+"""*********************************************************************************************"""
+
+
+###############
+# IMPORTATION #
+###############
+import os
+
+# -------------#
+from s3prl.utility.download import _urls_to_filepaths
+from .expert import UpstreamExpert as _UpstreamExpert
+
+
+def unispeech_sat_local(ckpt, *args, **kwargs):
+    """
+    The model from local ckpt
+        ckpt (str): PATH
+    """
+    assert os.path.isfile(ckpt)
+    return _UpstreamExpert(ckpt, *args, **kwargs)
+
+
+def unispeech_sat_url(ckpt, refresh=False, *args, **kwargs):
+    """
+    The model from google drive id
+        ckpt (str): URL
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    return unispeech_sat_local(
+        _urls_to_filepaths(ckpt, refresh=refresh), *args, **kwargs
+    )
+
+
+def unispeech_sat(refresh=False, *args, **kwargs):
+    """
+    The default model - Base-Plus
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    return unispeech_sat_base_plus(refresh=refresh, *args, **kwargs)
+
+
+def unispeech_sat_base(refresh=False, *args, **kwargs):
+    """
+    The Base model
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs["ckpt"] = "\"https://msranlcmtteamdrive.blob.core.windows.net/share/unispeech-sat/UniSpeech-SAT-Base.pt?sv=2020-08-04&st=2021-11-26T10%3A09%3A40Z&se=2022-11-27T10%3A09%3A00Z&sr=b&sp=r&sig=iHQ9HTPwajdzHPVXAsYWeYFbDQ4a%2BmVdpL9BpoKBa5g%3D\""
+    return unispeech_sat_url(refresh=refresh, *args, **kwargs)
+
+
+def unispeech_sat_base_plus(refresh=False, *args, **kwargs):
+    """
+    The Base-Plus model
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs["ckpt"] = "\"https://msranlcmtteamdrive.blob.core.windows.net/share/unispeech-sat/UniSpeech-SAT-Base+.pt?sv=2020-08-04&st=2021-11-26T10%3A10%3A25Z&se=2022-11-27T10%3A10%3A00Z&sr=b&sp=r&sig=plC0%2BNmN7Q18RgdmHBIrEBK2IuMUSW%2F0AnLqleO2JX8%3D\""
+    return unispeech_sat_url(refresh=refresh, *args, **kwargs)
+
+
+def unispeech_sat_large(refresh=False, *args, **kwargs):
+    """
+    The Large model
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs["ckpt"] = "\"https://msranlcmtteamdrive.blob.core.windows.net/share/unispeech-sat/UniSpeech-SAT-Large.pt?sv=2020-08-04&st=2021-11-26T10%3A10%3A59Z&se=2022-11-27T10%3A10%3A00Z&sr=b&sp=r&sig=U7cExvz%2Bt4mVGdN9mdRQ0U%2FodUuS25wGcHtoUmk2Dd4%3D\""
+    return unispeech_sat_url(refresh=refresh, *args, **kwargs)

--- a/s3prl/upstream/wavlm/WavLM.py
+++ b/s3prl/upstream/wavlm/WavLM.py
@@ -185,7 +185,7 @@ class WavLMConfig:
         self.dropout_features: float = 0.0     # dropout to apply to the features (after feat extr)
 
         # masking
-        self.mask_length: int = 10     # mask length)
+        self.mask_length: int = 10     # mask length
         self.mask_prob: float = 0.65     # probability of replacing a token with mask
         self.mask_selection: str = "static"     # how to choose mask length
         self.mask_other: float = 0     # secondary mask argument (used for more complex distributions), see help in compute_mask_indicesh

--- a/s3prl/upstream/wavlm/hubconf.py
+++ b/s3prl/upstream/wavlm/hubconf.py
@@ -41,7 +41,7 @@ def wavlm_url(ckpt, refresh=False, *args, **kwargs):
 
 def wavlm(refresh=False, *args, **kwargs):
     """
-    The default model - Base
+    The default model - Base-Plus
         refresh (bool): whether to download ckpt/config again if existed
     """
     return wavlm_base_plus(refresh=refresh, *args, **kwargs)
@@ -58,8 +58,17 @@ def wavlm_base(refresh=False, *args, **kwargs):
 
 def wavlm_base_plus(refresh=False, *args, **kwargs):
     """
-    The Large model
+    The Base-Plus model
         refresh (bool): whether to download ckpt/config again if existed
     """
     kwargs["ckpt"] = "\"https://msranlcmtteamdrive.blob.core.windows.net/share/wavlm/WavLM-Base+.pt?sv=2020-04-08&st=2021-11-05T00%3A34%3A47Z&se=2022-10-06T00%3A34%3A00Z&sr=b&sp=r&sig=Gkf1IByHaIn1t%2FVEd9D6WHjZ3zu%2Fk5eSdoj21UytKro%3D\""
+    return wavlm_url(refresh=refresh, *args, **kwargs)
+
+
+def wavlm_large(refresh=False, *args, **kwargs):
+    """
+    The Large model
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs["ckpt"] = "\"https://msranlcmtteamdrive.blob.core.windows.net/share/wavlm/WavLM-Large.pt?sv=2020-08-04&st=2021-11-26T10%3A13%3A14Z&se=2021-11-27T10%3A13%3A14Z&sr=b&sp=r&sig=bxMBntgXjgRQuRCj6BzTD8129rQ3eduP5cw0b%2FTe4Wg%3D\""
     return wavlm_url(refresh=refresh, *args, **kwargs)


### PR DESCRIPTION
Add the Unispeech-SAT upstream models.
Requested from Issue #245 

Paper: https://arxiv.org/abs/2110.05752
Code/Model: https://github.com/microsoft/UniSpeech/tree/main/UniSpeech-SAT