### PR TITLE
DDP training for MOSEI

### DIFF
--- a/s3prl/downstream/mosei/README.md
+++ b/s3prl/downstream/mosei/README.md
@@ -8,6 +8,8 @@ by following steps in `utility` directory.
 
 ## Data preparation
 
+### Download Dataset
+
 ```bash=
 cd /path/to/data
 
@@ -19,6 +21,33 @@ unzip CMU_MOSEI.zip
 mv Raw CMU_MOSEI
 ```
 Remember to modify data_dir in `config.yaml`
+
+### Segment the Audio
+
+Run `segment_audio.sh` by passing the location of your CMU-MOSEI Audio folder as an argument.
+
+```bash=
+bash segment_audio.sh /path/to/CMU_MOSEI/Audio
+# For example: bash segment_audio.sh /tmp/CMU_MOSEI/Audio
+```
+
+After that, you should have the following file structure under /path/to/CMU_MOSEI/Audio:
+
+```
+/path/to/CMU_MOSEI/Audio
+├── Full
+│   ├── COVAREP
+│   │   └── Many .mat files
+│   └── WAV_16000
+│       └── Many .wav files
+└── Segmented_Audio
+    ├── dev
+    │   └── Many .wav files (Dev set)
+    ├── test
+    │   └── Many .wav files (Test set)
+    └── train
+        └── Many .wav files (Train set)
+```
 
 ## Available Tasks
 Change `num_class` in the `config.yaml` to perform the following tasks:   

--- a/s3prl/downstream/mosei/README.md
+++ b/s3prl/downstream/mosei/README.md
@@ -36,8 +36,8 @@ Run `utility/segment_audio.py` by passing the location of your CMU-MOSEI Audio f
 This script is being used to segment the audio files into different split (train, dev, and test).
 
 ```bash=
-python3 ./utility/segment_audio.py /path/to/CMU_MOSEI/Audio
-# For example: python3 ./utility/segment_audio.py /tmp/CMU_MOSEI/Audio
+python ./utility/segment_audio.py /path/to/CMU_MOSEI/Audio
+# For example: python ./utility/segment_audio.py /tmp/CMU_MOSEI/Audio
 ```
 
 After that, you should have the following file structure under /path/to/CMU_MOSEI/Audio:
@@ -111,7 +111,7 @@ Use the following code to train a model using CMU-MOSEI as downstream dataset:
 python run_downstream.py -m train -n ExpName -u fbank -d mosei
 
 # Training w/ DDP
-CUDA_VISIBLE_DEVICES=0,1 python3 -m torch.distributed.launch --nproc_per_node 2 run_downstream.py -m train -n ExpName -u fbank -d mosei
+CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node 2 run_downstream.py -m train -n ExpName -u fbank -d mosei
 
 # Testing
 python run_downstream.py -m evaluate -n ExpName -u fbank -d mosei

--- a/s3prl/downstream/mosei/README.md
+++ b/s3prl/downstream/mosei/README.md
@@ -8,15 +8,21 @@ by following steps in `utility` directory.
 
 ## Data preparation
 
-```
-cd /path/to/data 
+### Download the Dataset
+
+```bash=
+cd /path/to/data
+
+# Download CMU-MOSEI Dataset
 wget http://immortal.multicomp.cs.cmu.edu/raw_datasets/CMU_MOSEI.zip
 unzip CMU_MOSEI.zip 
-mv Raw CMU-MOSEI
+
+# Set final path to dataset
+mv Raw CMU_MOSEI
 ```
 
 ## Available Tasks
-Change `num_clas` in the `config.yaml` to perform the following tasks:   
+Change `num_class` in the `config.yaml` to perform the following tasks:   
 1. **Two-class sentiment classication (`num_class: 2`)**  
 Labels: [0: negative, 1: non-negative] (positive and neutral are counted as non-negative).  
 2. **Three-class sentiment classification (`num_class: 3`)**  
@@ -27,13 +33,20 @@ Labels: [happy, sad, anger, surprise, disgust, fear]
 Labels: [-3: highly negative, -2: negative, -1: weakly negative, 0: neutral, 1: weakly positive, 2: positive, 3 highly positive]
 
 
-## Training
-~~~
-$ # train
-$ python run_downstream.py -m train -n ExpName -u fbank -d mosei
-$ # test
-$ python run_downstream.py -m evaluate -n ExpName -u fbank -d mosei
-~~~
-Consequently, you can calculate the accuracy and other metrics manually from the generated txt files.
+## Train a New Model
 
+If you want to modify the model architecture used for downstream training, please refer to `model.py` and modify the content.
+
+Use the following code to train a model using CMU-MOSEI as downstream dataset:
+```
+# Training w/o DDP
+python run_downstream.py -m train -n ExpName -u fbank -d mosei
+
+# Training w/ DDP
+CUDA_VISIBLE_DEVICES=0,1 python3 -m torch.distributed.launch --nproc_per_node 2 run_downstream.py -m train -n ExpName -u fbank -d mosei
+
+# Testing
+python run_downstream.py -m evaluate -n ExpName -u fbank -d mosei
+```
+Consequently, you can calculate the accuracy and other metrics manually from the generated txt files.
 

--- a/s3prl/downstream/mosei/README.md
+++ b/s3prl/downstream/mosei/README.md
@@ -22,7 +22,7 @@ mv Raw CMU_MOSEI
 ```
 Remember to modify data_dir in `config.yaml`
 
-### Segment the Audio
+### Segment the Audio Files
 
 Run `segment_audio.sh` by passing the location of your CMU-MOSEI Audio folder as an argument.
 

--- a/s3prl/downstream/mosei/README.md
+++ b/s3prl/downstream/mosei/README.md
@@ -22,13 +22,22 @@ mv Raw CMU_MOSEI
 ```
 Remember to modify data_dir in `config.yaml`
 
+### Install Dependencies
+
+Install dependencies using the following commands:
+```bash=
+pip install pydub pandas
+sudo apt-get install ffmpeg libavcodec-extra
+```
+
 ### Segment the Audio Files
 
-Run `segment_audio.sh` by passing the location of your CMU-MOSEI Audio folder as an argument.
+Run `utility/segment_audio.py` by passing the location of your CMU-MOSEI Audio folder as an argument.
+This script is being used to segment the audio files into different split (train, dev, and test).
 
 ```bash=
-bash segment_audio.sh /path/to/CMU_MOSEI/Audio
-# For example: bash segment_audio.sh /tmp/CMU_MOSEI/Audio
+python3 ./utility/segment_audio.py /path/to/CMU_MOSEI/Audio
+# For example: python3 ./utility/segment_audio.py /tmp/CMU_MOSEI/Audio
 ```
 
 After that, you should have the following file structure under /path/to/CMU_MOSEI/Audio:

--- a/s3prl/downstream/mosei/README.md
+++ b/s3prl/downstream/mosei/README.md
@@ -8,8 +8,6 @@ by following steps in `utility` directory.
 
 ## Data preparation
 
-### Download the Dataset
-
 ```bash=
 cd /path/to/data
 
@@ -20,6 +18,7 @@ unzip CMU_MOSEI.zip
 # Set final path to dataset
 mv Raw CMU_MOSEI
 ```
+Remember to modify data_dir in `config.yaml`
 
 ## Available Tasks
 Change `num_class` in the `config.yaml` to perform the following tasks:   
@@ -32,10 +31,41 @@ Labels: [happy, sad, anger, surprise, disgust, fear]
 4. **Seven-class sentiment classification (`num_clases: 7`)**  
 Labels: [-3: highly negative, -2: negative, -1: weakly negative, 0: neutral, 1: weakly positive, 2: positive, 3 highly positive]
 
+## Customize Downstream Model
+If you want to modify the model architecture used for downstream training, please modify the content of `model.py` and `config.yaml`. For example, if you want to use a transformer-encoder-based model:
+- In `model.py`, change Model to:
+```python=
+class Model(nn.Module):
+    def __init__(self, input_dim, output_class_num, **kwargs):
+        super(Model, self).__init__()
+        self.enc_layer = nn.TransformerEncoderLayer(
+            input_dim, **kwargs['enc']
+        )
+        self.encoder = nn.TransformerEncoder(
+            self.enc_layer, kwargs['enc_layers']
+        )
+        self.linear = nn.Sequential(
+            nn.Linear(input_dim, output_class_num)
+        )
+
+    def forward(self, features):
+        x = self.encoder(features)
+        pooled = x.mean(dim=1)
+        predicted = self.linear(pooled)
+        return predicted
+```
+
+- In `config.yaml`, change modelrc to:
+```python=
+  modelrc:
+    input_dim: 256
+    enc:
+      nhead: 2
+      batch_first: True
+    enc_layers: 2
+```
 
 ## Train a New Model
-
-If you want to modify the model architecture used for downstream training, please refer to `model.py` and modify the content.
 
 Use the following code to train a model using CMU-MOSEI as downstream dataset:
 ```

--- a/s3prl/downstream/mosei/config.yaml
+++ b/s3prl/downstream/mosei/config.yaml
@@ -23,7 +23,7 @@ scheduler:
 
 downstream_expert:
   datarc:
-    data_dir: /data/CMU-MOSEI/Audio
+    data_dir: /data1/jonathanhsu/CMU-MOSEI/Audio
     label_path: ./downstream/mosei/utility/CMU_MOSEI_Labels.csv
     num_class: 2  # options: 2, 3, 6, 7
     num_workers: 12

--- a/s3prl/downstream/mosei/segment_audio.sh
+++ b/s3prl/downstream/mosei/segment_audio.sh
@@ -1,0 +1,3 @@
+pip install pydub pandas
+sudo apt-get install ffmpeg libavcodec-extra
+python3 ./utility/segment_audio.py $1

--- a/s3prl/downstream/mosei/segment_audio.sh
+++ b/s3prl/downstream/mosei/segment_audio.sh
@@ -1,3 +1,0 @@
-pip install pydub pandas
-sudo apt-get install ffmpeg libavcodec-extra
-python3 ./utility/segment_audio.py $1

--- a/s3prl/downstream/mosei/utility/README.md
+++ b/s3prl/downstream/mosei/utility/README.md
@@ -1,81 +1,50 @@
 Notes:  
-1. convert_label.sh is used to generate CMU_MOSEI_Labels.csv.
-   You may need to change permission of that bash file to run.
-   ~~~
-   $ chmod +x convert_label.sh
-   $ ./convert_label.sh
-   ~~~
+convert_label.sh is used to generate CMU_MOSEI_Labels.csv.
+You may need to change permission of that bash file to run.
+```
+chmod +x convert_label.sh
+./convert_label.sh
+```
 
-   You will get the messsage below if generation of csv file success.
-   ~~~
-   Info of Dataset
-   ---------- Original Video -----------                                  
-   Num of videos in training   set:  2249                                          
-   Num of videos in validation set:  300                                           
-   Num of videos in testing    set:  678
-   -------------------------------------
-   ---------- Segmented Audio ----------
-   Num of Training   Data:  16327
-   Num of Validation Data:  1871
-   Num of Testing    Data:  4662
-   Num of Useless    Data:  399
-   Num of Useful     Data:  22860
-   Total             Data:  23259
-   --------------------------------------
-   ---------- 2-class sentiment ---------
-   Class non-negative (1):  16576
-   Class negative     (0):  6683
-   --------------------------------------
-   ---------- 3-class sentiment ---------
-   Class positive (1):  11476
-   Class neutral (0):  6683
-   Class negative (-1):  5100
-   --------------------------------------
-   --------- 6-class emotion ------------
-   Class happiness (1):  14567
-   Class sadness   (2):  3782
-   Class anger     (3):  2730
-   Class surprise  (4):  437
-   Class disgust   (5):  1291
-   Class fear      (6):  452
-   --------------------------------------
-   --------- 7-class sentiment ----------
-   Class -3:  821
-   Class -2:  2253
-   Class -1:  3609
-   Class +0:  5100
-   Class +1:  7576
-   Class +2:  3225
-   Class +3:  675
-   ~~~
-
-2. Install necessary additional packages. In Ubuntu,
-   ~~~
-   $ sudo apt install ffmpeg libavcodec-extra
-   ~~~
-
-3. segment_audio.py is used to segment audio files. 
-   Run this python file by giving a location of your CMU-MOSEI Audio as an argument.
-   ~~~
-   $ python segment_audio.py /path/to/CMU_MOSEI/Audio
-   ~~~
-   You may need to install additional python packages (pydub, pandas) to run 
-   that python file.
-
-   After that, you should have the following file structure under /path/to/Audio:
-
-   ```
-   /path/to/Audio
-   ├── Full
-   │   ├── COVAREP
-   │   │   └── Many .mat files
-   │   └── WAV_16000
-   │       └── Many .wav files
-   └── Segmented_Audio
-      ├── dev
-      │   └── Many .wav files (Dev set)
-      ├── test
-      │   └── Many .wav files (Test set)
-      └── train
-          └── Many .wav files (Train set)
-   ```
+You will get the messsage below if generation of csv file success.
+```
+Info of Dataset
+---------- Original Video -----------                                  
+Num of videos in training   set:  2249                                          
+Num of videos in validation set:  300                                           
+Num of videos in testing    set:  678
+-------------------------------------
+---------- Segmented Audio ----------
+Num of Training   Data:  16327
+Num of Validation Data:  1871
+Num of Testing    Data:  4662
+Num of Useless    Data:  399
+Num of Useful     Data:  22860
+Total             Data:  23259
+--------------------------------------
+---------- 2-class sentiment ---------
+Class non-negative (1):  16576
+Class negative     (0):  6683
+--------------------------------------
+---------- 3-class sentiment ---------
+Class positive (1):  11476
+Class neutral (0):  6683
+Class negative (-1):  5100
+--------------------------------------
+--------- 6-class emotion ------------
+Class happiness (1):  14567
+Class sadness   (2):  3782
+Class anger     (3):  2730
+Class surprise  (4):  437
+Class disgust   (5):  1291
+Class fear      (6):  452
+--------------------------------------
+--------- 7-class sentiment ----------
+Class -3:  821
+Class -2:  2253
+Class -1:  3609
+Class +0:  5100
+Class +1:  7576
+Class +2:  3225
+Class +3:  675
+```

--- a/s3prl/downstream/mosei/utility/README.md
+++ b/s3prl/downstream/mosei/utility/README.md
@@ -5,10 +5,55 @@ Notes:
    $ chmod +x convert_label.sh
    $ ./convert_label.sh
    ~~~
+
+   You will get the messsage below if generation of csv file success.
+   ~~~
+   Info of Dataset
+   ---------- Original Video -----------                                  
+   Num of videos in training   set:  2249                                          
+   Num of videos in validation set:  300                                           
+   Num of videos in testing    set:  678
+   -------------------------------------
+   ---------- Segmented Audio ----------
+   Num of Training   Data:  16327
+   Num of Validation Data:  1871
+   Num of Testing    Data:  4662
+   Num of Useless    Data:  399
+   Num of Useful     Data:  22860
+   Total             Data:  23259
+   --------------------------------------
+   ---------- 2-class sentiment ---------
+   Class non-negative (1):  16576
+   Class negative     (0):  6683
+   --------------------------------------
+   ---------- 3-class sentiment ---------
+   Class positive (1):  11476
+   Class neutral (0):  6683
+   Class negative (-1):  5100
+   --------------------------------------
+   --------- 6-class emotion ------------
+   Class happiness (1):  14567
+   Class sadness   (2):  3782
+   Class anger     (3):  2730
+   Class surprise  (4):  437
+   Class disgust   (5):  1291
+   Class fear      (6):  452
+   --------------------------------------
+   --------- 7-class sentiment ----------
+   Class -3:  821
+   Class -2:  2253
+   Class -1:  3609
+   Class +0:  5100
+   Class +1:  7576
+   Class +2:  3225
+   Class +3:  675
+   ~~~
+
 2. Install necessary additional packages. In Ubuntu,
    ~~~
    $ sudo apt install ffmpeg libavcodec-extra
    ~~~
+
 3. segment_audio.py is used to segment audio files. 
    Run this python file by giving a location of your CMU-MOSEI Audio as an argument.
    ~~~
@@ -17,46 +62,20 @@ Notes:
    You may need to install additional python packages (pydub, pandas) to run 
    that python file.
 
+   After that, you should have the following file structure under /path/to/Audio:
 
-You will get the messsage below if generation of csv file success.
-~~~
-Info of Dataset
----------- Original Video -----------                                  
-Num of videos in training   set:  2249                                          
-Num of videos in validation set:  300                                           
-Num of videos in testing    set:  678
--------------------------------------
----------- Segmented Audio ----------
-Num of Training   Data:  16327
-Num of Validation Data:  1871
-Num of Testing    Data:  4662
-Num of Useless    Data:  399
-Num of Useful     Data:  22860
-Total             Data:  23259
---------------------------------------
----------- 2-class sentiment ---------
-Class non-negative (1):  16576
-Class negative     (0):  6683
---------------------------------------
----------- 3-class sentiment ---------
-Class positive (1):  11476
-Class neutral (0):  6683
-Class negative (-1):  5100
---------------------------------------
---------- 6-class emotion ------------
-Class happiness (1):  14567
-Class sadness   (2):  3782
-Class anger     (3):  2730
-Class surprise  (4):  437
-Class disgust   (5):  1291
-Class fear      (6):  452
---------------------------------------
---------- 7-class sentiment ----------
-Class -3:  821
-Class -2:  2253
-Class -1:  3609
-Class +0:  5100
-Class +1:  7576
-Class +2:  3225
-Class +3:  675
-~~~
+   ```
+   /path/to/Audio
+   ├── Full
+   │   ├── COVAREP
+   │   │   └── Many .mat files
+   │   └── WAV_16000
+   │       └── Many .wav files
+   └── Segmented_Audio
+      ├── dev
+      │   └── Many .wav files (Dev set)
+      ├── test
+      │   └── Many .wav files (Test set)
+      └── train
+         └── Many .wav files (Train set)
+   ```

--- a/s3prl/downstream/mosei/utility/README.md
+++ b/s3prl/downstream/mosei/utility/README.md
@@ -57,7 +57,7 @@ Notes:
 3. segment_audio.py is used to segment audio files. 
    Run this python file by giving a location of your CMU-MOSEI Audio as an argument.
    ~~~
-   $ python segment_audio.py /path/to/CMU-MOSEI/Audio
+   $ python segment_audio.py /path/to/CMU_MOSEI/Audio
    ~~~
    You may need to install additional python packages (pydub, pandas) to run 
    that python file.
@@ -77,5 +77,5 @@ Notes:
       ├── test
       │   └── Many .wav files (Test set)
       └── train
-         └── Many .wav files (Train set)
+          └── Many .wav files (Train set)
    ```


### PR DESCRIPTION
Added DDP training for MOSEI (related to issue #195)

The code has been tested with
 
```
# Training using wav2vec2 as upstream
CUDA_VISIBLE_DEVICES=0,1 python3 -m torch.distributed.launch --nproc_per_node 2 run_downstream.py -m train -u wav2vec2 -d mosei -n Test --upstream_trainable --upstream_feature_selection last_hidden_state
```

Part of the added code is adapted from https://github.com/s3prl/s3prl/issues/188#issuecomment-944946822 and https://github.com/s3prl/s3prl/pull/285
