### PR TITLE
huggingface_hub version correction for python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "easydict",
     "catalyst",
     "sentencepiece",
-    "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git#egg=huggingface_hub", # TODO: Replace with v0.0.17 when it is released
+    "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git@v0.0.16#egg=huggingface_hub-v0.0.16", # TODO: Replace with v0.0.17 when it is released
     "mutagen"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "easydict",
     "catalyst",
     "sentencepiece",
-    "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git@v0.0.16#egg=huggingface_hub-v0.0.16", # TODO: Replace with v0.0.17 when it is released
+    "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git@v0.0.17#egg=huggingface_hub-v0.0.17", # TODO: Replace with v0.0.17 when it is released
     "mutagen"
 ]
 


### PR DESCRIPTION
        The original setup.py would try to install a more recent version of huggingface_hub, which requires python version >=3.8. To resolve this problem in python 3.6.10, the version of huggingfuac_hub has to be specified (tag v0.0.16 is applied in this correction). 
        This change is implemented by modifying the setup.py file. The 
original string in line 47 is replaced by the following one:

"huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git@v0.0.16#egg=huggingface_hub-v0.0.16"

By doing so, the version of huggingface_hub is successfully specified and the package can be installed in python 3.6.10 envirnment.