### PR TITLE
fix loading customized mockingjay upstream model

### DIFF
--- a/s3prl/upstream/mockingjay/expert.py
+++ b/s3prl/upstream/mockingjay/expert.py
@@ -23,11 +23,19 @@ class UpstreamExpert(UpstreamBase):
     The Mockingjay wrapper
     """
 
-    def __init__(self, ckpt, model_config=None, **kwargs):
+    def __init__(self, ckpt, options_config=None, **kwargs):
         super().__init__(**kwargs)
 
-        ## decide load options of mockingjay
-        default_options = {
+        if options_config is not None:
+            print(
+                "[UpstreamExpert] - Using upstream expert config file from:",
+                options_config,
+            )
+            with open(options_config, "r") as file:
+                options = yaml.load(file, Loader=yaml.FullLoader)
+        else:
+            print("[UpstreamExpert] - Using the default upstream expert config")
+            options = {
                 "load_pretrain": "True",
                 "no_grad": "False",
                 "dropout": "default",
@@ -36,26 +44,6 @@ class UpstreamExpert(UpstreamBase):
                 "output_hidden_states": "True",
                 "permute_input": "False",
             }
-
-        if model_config is not None:
-            print(
-                "[UpstreamExpert] - Using upstream expert config file from:",
-                model_config,
-            )
-            with open(model_config, "r") as file:
-                options = yaml.load(file, Loader=yaml.FullLoader)
-            if "options" in options:
-                for key in default_options:
-                    if key not in options["options"]:
-                        options[key] = default_options[key]
-                    else:
-                        options[key] = options["options"][key]
-            else:
-                options.update(default_options)
-
-        else:
-            print("[UpstreamExpert] - Using the default upstream expert config")
-            options = default_options
 
         options["ckpt_file"] = ckpt
         options["select_layer"] = -1

--- a/s3prl/upstream/mockingjay/expert.py
+++ b/s3prl/upstream/mockingjay/expert.py
@@ -26,16 +26,8 @@ class UpstreamExpert(UpstreamBase):
     def __init__(self, ckpt, model_config=None, **kwargs):
         super().__init__(**kwargs)
 
-        if model_config is not None:
-            print(
-                "[UpstreamExpert] - Using upstream expert config file from:",
-                model_config,
-            )
-            with open(model_config, "r") as file:
-                options = yaml.load(file, Loader=yaml.FullLoader)
-        else:
-            print("[UpstreamExpert] - Using the default upstream expert config")
-            options = {
+        ## decide load options of mockingjay
+        default_options = {
                 "load_pretrain": "True",
                 "no_grad": "False",
                 "dropout": "default",
@@ -44,6 +36,26 @@ class UpstreamExpert(UpstreamBase):
                 "output_hidden_states": "True",
                 "permute_input": "False",
             }
+
+        if model_config is not None:
+            print(
+                "[UpstreamExpert] - Using upstream expert config file from:",
+                model_config,
+            )
+            with open(model_config, "r") as file:
+                options = yaml.load(file, Loader=yaml.FullLoader)
+            if "options" in options:
+                for key in default_options:
+                    if key not in options["options"]:
+                        options[key] = default_options[key]
+                    else:
+                        options[key] = options["options"][key]
+            else:
+                options.update(default_options)
+
+        else:
+            print("[UpstreamExpert] - Using the default upstream expert config")
+            options = default_options
 
         options["ckpt_file"] = ckpt
         options["select_layer"] = -1

--- a/s3prl/upstream/mockingjay/hubconf.py
+++ b/s3prl/upstream/mockingjay/hubconf.py
@@ -17,16 +17,16 @@ from s3prl.utility.download import _gdriveids_to_filepaths, _urls_to_filepaths
 from .expert import UpstreamExpert as _UpstreamExpert
 
 
-def mockingjay_local(ckpt, model_config=None, *args, **kwargs):
+def mockingjay_local(ckpt, options_config=None, *args, **kwargs):
     """
         The model from local ckpt
             ckpt (str): PATH
             feature_selection (int): -1 (default, the last layer) or an int in range(0, max_layer_num)
     """
     assert os.path.isfile(ckpt)
-    if model_config is not None:
-        assert os.path.isfile(model_config)
-    return _UpstreamExpert(ckpt, model_config, *args, **kwargs)
+    if options_config is not None:
+        assert os.path.isfile(options_config)
+    return _UpstreamExpert(ckpt, options_config, *args, **kwargs)
 
 
 def mockingjay_gdriveid(ckpt, refresh=False, *args, **kwargs):


### PR DESCRIPTION
Fix issue reported in #215

The problem is that example config in [config_model.yaml](https://github.com/s3prl/s3prl/blob/master/s3prl/pretrain/mockingjay/config_model.yaml) doesn't show some options that are actually required when users wants to load their customized model. (Because this issue will not be triggered if `model_config` is set to `None` in `mockingjay_local()` and this won't happen unless users specify their own pretrained model config)

This work is just trying to set to default options if user does not specify these required options in their `options` section in `config_model.yaml`

