### PR TITLE
fix downsample rate error when using wav2vec_hub as upstream

### DIFF
--- a/s3prl/upstream/wav2vec2_hug/expert.py
+++ b/s3prl/upstream/wav2vec2_hug/expert.py
@@ -15,6 +15,9 @@ class UpstreamExpert(nn.Module):
         self.processor = Wav2Vec2Processor.from_pretrained(ckpt)
         self.model = Wav2Vec2Model.from_pretrained(ckpt)
 
+    def get_downsample_rates(self, key: str) -> int:
+        return 320
+
     def forward(self, wavs: List[Tensor]):
         device = wavs[0].device
         processor_outputs = self.processor(


### PR DESCRIPTION
<img width="987" alt="image" src="https://user-images.githubusercontent.com/58504997/163218391-56c4c5c0-a8b3-49bc-8ede-26998a8500d4.png">

fixed this issue due to undeclared function "get_downsample_rates"