### PR TITLE
add wav2vec2 models for issue #219

### DIFF
--- a/s3prl/upstream/wav2vec2/hubconf.py
+++ b/s3prl/upstream/wav2vec2/hubconf.py
@@ -78,3 +78,12 @@ def wav2vec2_xlsr(refresh=False, *args, **kwargs):
     """
     kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/xlsr_53_56k.pt'
     return wav2vec2_url(refresh=refresh, *args, **kwargs)
+
+
+def wav2vec2_large_lv60_cv_swbd_fsh(refresh=False, *args, **kwargs):
+    """
+        The Large model trained on Libri-Light 60k hours + CommonVoice + Switchboard + Fisher
+            refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/w2v_large_lv_fsh_swbd_cv.pt'
+    return wav2vec2_url(refresh=refresh, *args, **kwargs)

--- a/s3prl/upstream/wav2vec2_hug/hubconf.py
+++ b/s3prl/upstream/wav2vec2_hug/hubconf.py
@@ -20,3 +20,8 @@ def wav2vec2_hug_base_960(*args, **kwargs):
 def wav2vec2_hug_large_ll60k(*args, **kwargs):
     kwargs['ckpt'] = 'facebook/wav2vec2-large-lv60'
     return wav2vec2_hug(*args, **kwargs)
+
+
+def wav2vec2_hug_large_lv60_self_training(*args, **kwargs):
+    kwargs['ckpt'] = 'facebook/wav2vec2-large-960h-lv60-self'
+    return wav2vec2_hug(*args, **kwargs)


### PR DESCRIPTION
This issue request for two models: 

* "Wav2Vec 2.0 Large (LV-60) + Self Training"
* "Wav2Vec 2.0 Large (LV-60 + CV + SWBD + FSH)"

Which are available now by `-u wav2vec2_hug_large_lv60_self_training` & `-u wav2vec2_large_lv60_cv_swbd_fsh`, respectively.