### PR TITLE
Add hubert robust

### DIFF
--- a/s3prl/upstream/README.md
+++ b/s3prl/upstream/README.md
@@ -86,7 +86,7 @@ Jun 14 2021 | HuBERT | hubert / hubert_large_ll60k | [arxiv](https://arxiv.org/a
 Dec 3 2019 | DeCoAR | decoar | [arxiv](https://arxiv.org/abs/1912.01679) | Mel | 10ms | [LibriSpeech-960](http://www.openslr.org/12) | O | [speech-representations](https://github.com/awslabs/speech-representations)
 Dec 11 2020 | DeCoAR 2.0 | decoar2 | [arxiv](https://arxiv.org/abs/2012.06659) | Mel | 10ms | [LibriSpeech-960](http://www.openslr.org/12) | O | [speech-representations](https://github.com/awslabs/speech-representations)
 Oct 5 2021 | DistilHuBERT | distilhubert | [arxiv](https://arxiv.org/abs/2110.01900) | wav | 20ms | [LibriSpeech-960](http://www.openslr.org/12) | O | [S3PRL](https://github.com/s3prl/s3prl)
-Jun 14 2021 | HuBERT | hubert / hubert_large_ll60k | [arxiv](https://arxiv.org/abs/2203.16104) | wav | 20ms | [LibriSpeech-960](http://www.openslr.org/12) | X | Unavailable
+May 27 2022 | Robust HuBERT | hubert_base_robust_mgr | [arxiv](https://arxiv.org/abs/2203.16104) | wav | 20ms | [LibriSpeech-960](http://www.openslr.org/12) with mgr distortion | X | Unavailable
 ### Acoustic Feature Upstreams
 
 We also provide classic acoustic features as baselines. For each upstream with `Name`, you can configure their options (available by their `Backend`) in `s3prl/upstream/baseline/Name.yaml`.

--- a/s3prl/upstream/README.md
+++ b/s3prl/upstream/README.md
@@ -86,7 +86,7 @@ Jun 14 2021 | HuBERT | hubert / hubert_large_ll60k | [arxiv](https://arxiv.org/a
 Dec 3 2019 | DeCoAR | decoar | [arxiv](https://arxiv.org/abs/1912.01679) | Mel | 10ms | [LibriSpeech-960](http://www.openslr.org/12) | O | [speech-representations](https://github.com/awslabs/speech-representations)
 Dec 11 2020 | DeCoAR 2.0 | decoar2 | [arxiv](https://arxiv.org/abs/2012.06659) | Mel | 10ms | [LibriSpeech-960](http://www.openslr.org/12) | O | [speech-representations](https://github.com/awslabs/speech-representations)
 Oct 5 2021 | DistilHuBERT | distilhubert | [arxiv](https://arxiv.org/abs/2110.01900) | wav | 20ms | [LibriSpeech-960](http://www.openslr.org/12) | O | [S3PRL](https://github.com/s3prl/s3prl)
-
+Jun 14 2021 | HuBERT | hubert / hubert_large_ll60k | [arxiv](https://arxiv.org/abs/2203.16104) | wav | 20ms | [LibriSpeech-960](http://www.openslr.org/12) | X | Unavailable
 ### Acoustic Feature Upstreams
 
 We also provide classic acoustic features as baselines. For each upstream with `Name`, you can configure their options (available by their `Backend`) in `s3prl/upstream/baseline/Name.yaml`.

--- a/s3prl/upstream/hubert/hubconf.py
+++ b/s3prl/upstream/hubert/hubconf.py
@@ -66,8 +66,8 @@ def hubert_large_ll60k(refresh=False, *args, **kwargs):
 
 def hubert_base_robust_mgr(refresh=False, *args, **kwargs):
     """
-    The Base model
+    The Base model, continually trained with Libri 960 hr with Musan noise, Gaussian noise and Reverberation.
         refresh (bool): whether to download ckpt/config again if existed
     """
-    kwargs["ckpt"] = "https://www.dropbox.com/s/wfdfvv0dqsj1av9/checkpoint.best_loss_2.7821.pt?dl=0"
+    kwargs["ckpt"] = "https://huggingface.co/kphuang68/HuBERT_base_robust_mgr/resolve/main/HuBERT_base_robust_mgr_best_loss_2.7821.pt"
     return hubert_url(refresh=refresh, *args, **kwargs)

--- a/s3prl/upstream/hubert/hubconf.py
+++ b/s3prl/upstream/hubert/hubconf.py
@@ -62,3 +62,12 @@ def hubert_large_ll60k(refresh=False, *args, **kwargs):
     """
     kwargs["ckpt"] = "https://dl.fbaipublicfiles.com/hubert/hubert_large_ll60k.pt"
     return hubert_url(refresh=refresh, *args, **kwargs)
+
+
+def hubert_base_robust_mgr(refresh=False, *args, **kwargs):
+    """
+    The Base model
+        refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs["ckpt"] = "https://www.dropbox.com/s/wfdfvv0dqsj1av9/checkpoint.best_loss_2.7821.pt?dl=0"
+    return hubert_url(refresh=refresh, *args, **kwargs)


### PR DESCRIPTION
Add a new upstream model.
HuBERT base continually trained with Libri 960 hr with Musan noise, Gaussian noise, and Reverberation.