### PR TITLE
Fix XLSR-53

### DIFF
--- a/s3prl/upstream/wav2vec2/expert.py
+++ b/s3prl/upstream/wav2vec2/expert.py
@@ -8,14 +8,22 @@
 
 
 import argparse
+import tempfile
+import dataclasses
 from typing import List
 from packaging import version
+from filelock import FileLock
 
 import torch
 import fairseq
 import numpy as np
 import torch.nn.functional as F
 from torch.nn.utils.rnn import pad_sequence
+
+from omegaconf import OmegaConf, open_dict
+from s3prl.utility.helper import zero_mean_unit_var_norm
+from fairseq.tasks.audio_finetuning import AudioFinetuningConfig
+from fairseq.tasks.audio_pretraining import AudioPretrainingConfig
 
 from ..interfaces import UpstreamBase
 from s3prl.utility.helper import zero_mean_unit_var_norm
@@ -28,7 +36,7 @@ class UpstreamExpert(UpstreamBase):
             "0.10.2"
         ), "Please install the fairseq master branch."
 
-        model, cfg, task = fairseq.checkpoint_utils.load_model_ensemble_and_task([ckpt])
+        model, cfg, task = self.load_model(ckpt)
         self.model = model[0]
         self.wav_normalize = cfg.task.normalize
 
@@ -51,7 +59,53 @@ class UpstreamExpert(UpstreamBase):
                 unpad_len = min([hidden.size(1) for hidden in hiddens])
                 hiddens = [hidden[:, :unpad_len, :] for hidden in hiddens]
                 return list(zip(names, hiddens))
+
             self.hook_postprocess = postprocess
+
+        self._init_layerdrop = self.model.encoder.layerdrop
+
+    @staticmethod
+    def load_model(ckpt_path: str):
+        """
+        Sanitize the config in the checkpoint as there are some irrelevant fields
+        in the released checkpoint which can cause the model loading to fail
+        """
+
+        fields_pretraining = [
+            field.name for field in dataclasses.fields(AudioPretrainingConfig)
+        ]
+        ckpt_state = torch.load(ckpt_path, map_location="cpu")
+
+        with open_dict(ckpt_state["cfg"]):
+            ckpt_changed = False
+            for key in list(ckpt_state["cfg"]["task"].keys()):
+                if key not in fields_pretraining:
+                    ckpt_state["cfg"]["task"].pop(key)
+                    ckpt_changed = True
+
+        if ckpt_changed:
+            with tempfile.NamedTemporaryFile() as file:
+                with FileLock(f"{file.name}.lock"):
+                    torch.save(ckpt_state, file.name)
+                (
+                    model,
+                    cfg,
+                    task,
+                ) = fairseq.checkpoint_utils.load_model_ensemble_and_task([file.name])
+
+        return model, cfg, task
+
+    @property
+    def layer_drop(self):
+        return self.model.encoder.layerdrop
+
+    def set_layer_drop(self, layerdrop: float = None):
+        if isinstance(layerdrop, float):
+            self.model.encoder.layerdrop = layerdrop
+        elif layerdrop is None:
+            self.model.encoder.layerdrop = self._init_layerdrop
+        else:
+            raise ValueError("layerdrop can only be float or None")
 
     def get_downsample_rates(self, key: str) -> int:
         return 320


### PR DESCRIPTION
The original wav2vec2 code can not successfully load the XLSR checkpoint due to there are extra config fields (related to AudioFinetuning) not recognized by the public fairseq Wav2vec2Config. This PR remove those extra fields before loading the model.