### PR TITLE
add xlsr-53 and xls-r

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ spk2utt
 experiment
 *.tar.gz
 *.tsv
+docs/source

--- a/s3prl/upstream/hubert/expert.py
+++ b/s3prl/upstream/hubert/expert.py
@@ -43,6 +43,7 @@ class UpstreamExpert(UpstreamBase):
             [ckpt]
         )
         self.model = model[0]
+        self.model.feature_grad_mult = 0.0
         self.task = task
 
         if len(self.hooks) == 0:

--- a/s3prl/upstream/unispeech_sat/expert.py
+++ b/s3prl/upstream/unispeech_sat/expert.py
@@ -39,6 +39,7 @@ class UpstreamExpert(UpstreamBase):
         self.cfg = WavLMConfig(checkpoint['cfg'])
         self.model = WavLM(self.cfg)
         self.model.load_state_dict(checkpoint['model'])
+        self.model.feature_grad_mult = 0.0
 
         if len(self.hooks) == 0:
             module_name = "self.model.encoder.layers"

--- a/s3prl/upstream/wav2vec2/expert.py
+++ b/s3prl/upstream/wav2vec2/expert.py
@@ -35,6 +35,7 @@ class UpstreamExpert(UpstreamBase):
 
         model, cfg, task = self.load_model(ckpt)
         self.model = model[0]
+        self.model.feature_grad_mult = 0.0
         self.wav_normalize = cfg.task.normalize
 
         # These options are only used for aligning representations between s3prl and huggingface

--- a/s3prl/upstream/wav2vec2/expert.py
+++ b/s3prl/upstream/wav2vec2/expert.py
@@ -8,14 +8,19 @@
 
 
 import argparse
+import tempfile
+import dataclasses
 from typing import List
 from packaging import version
+from filelock import FileLock
 
 import torch
 import fairseq
+import omegaconf
 import numpy as np
 import torch.nn.functional as F
 from torch.nn.utils.rnn import pad_sequence
+from fairseq.tasks.audio_pretraining import AudioPretrainingConfig
 
 from ..interfaces import UpstreamBase
 from s3prl.utility.helper import zero_mean_unit_var_norm
@@ -28,7 +33,7 @@ class UpstreamExpert(UpstreamBase):
             "0.10.2"
         ), "Please install the fairseq master branch."
 
-        model, cfg, task = fairseq.checkpoint_utils.load_model_ensemble_and_task([ckpt])
+        model, cfg, task = self.load_model(ckpt)
         self.model = model[0]
         self.wav_normalize = cfg.task.normalize
 
@@ -51,7 +56,57 @@ class UpstreamExpert(UpstreamBase):
                 unpad_len = min([hidden.size(1) for hidden in hiddens])
                 hiddens = [hidden[:, :unpad_len, :] for hidden in hiddens]
                 return list(zip(names, hiddens))
+
             self.hook_postprocess = postprocess
+
+        self._init_layerdrop = self.model.encoder.layerdrop
+
+    @staticmethod
+    def load_model(ckpt_path: str):
+        """
+        Sanitize the config in the checkpoint as there are some irrelevant fields
+        in the released checkpoint which can cause the model loading to fail
+        """
+        ckpt_state = torch.load(ckpt_path, map_location="cpu")
+
+        def fix_cfg(cfg):
+            for key in list(cfg.keys()):
+                if key not in ["task", "model"]:
+                    cfg.pop(key)
+
+            fields_pretraining = [
+                field.name for field in dataclasses.fields(AudioPretrainingConfig)
+            ]
+            for key in list(cfg["task"].keys()):
+                if key not in fields_pretraining:
+                    cfg["task"].pop(key)
+
+        if "cfg" in ckpt_state:
+            cfg = ckpt_state["cfg"]
+            if isinstance(cfg, omegaconf.DictConfig):
+                with omegaconf.open_dict(cfg):
+                    fix_cfg(cfg)
+            else:
+                fix_cfg(cfg)
+
+            if not isinstance(cfg, omegaconf.DictConfig):
+                cfg = omegaconf.OmegaConf.create(cfg)
+            ckpt_state["cfg"] = cfg
+
+        model, cfg, task = fairseq.checkpoint_utils.load_model_ensemble_and_task([ckpt_path], state=ckpt_state)
+        return model, cfg, task
+
+    @property
+    def layer_drop(self):
+        return self.model.encoder.layerdrop
+
+    def set_layer_drop(self, layerdrop: float = None):
+        if isinstance(layerdrop, float):
+            self.model.encoder.layerdrop = layerdrop
+        elif layerdrop is None:
+            self.model.encoder.layerdrop = self._init_layerdrop
+        else:
+            raise ValueError("layerdrop can only be float or None")
 
     def get_downsample_rates(self, key: str) -> int:
         return 320

--- a/s3prl/upstream/wav2vec2/hubconf.py
+++ b/s3prl/upstream/wav2vec2/hubconf.py
@@ -71,7 +71,16 @@ def wav2vec2_large_ll60k(refresh=False, *args, **kwargs):
     return wav2vec2_url(refresh=refresh, *args, **kwargs)
 
 
-def wav2vec2_xlsr(refresh=False, *args, **kwargs):
+def wav2vec2_large_lv60_cv_swbd_fsh(refresh=False, *args, **kwargs):
+    """
+        The Large model trained on Libri-Light 60k hours + CommonVoice + Switchboard + Fisher
+            refresh (bool): whether to download ckpt/config again if existed
+    """
+    kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/w2v_large_lv_fsh_swbd_cv.pt'
+    return wav2vec2_url(refresh=refresh, *args, **kwargs)
+
+
+def xlsr_53(refresh=False, *args, **kwargs):
     """
         The wav2vec 2.0 model trained on multilingual presented in https://arxiv.org/abs/2006.13979
             refresh (bool): whether to download ckpt/config again if existed
@@ -80,10 +89,19 @@ def wav2vec2_xlsr(refresh=False, *args, **kwargs):
     return wav2vec2_url(refresh=refresh, *args, **kwargs)
 
 
-def wav2vec2_large_lv60_cv_swbd_fsh(refresh=False, *args, **kwargs):
+def xls_r_300m(refresh=False, *args, **kwargs):
     """
-        The Large model trained on Libri-Light 60k hours + CommonVoice + Switchboard + Fisher
-            refresh (bool): whether to download ckpt/config again if existed
+    XLS-R, this smallest size has the same parameters as the Largs model of wav2vec 2.0 and HuBERT
     """
-    kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/w2v_large_lv_fsh_swbd_cv.pt'
+    kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/xlsr2_300m.pt'
+    return wav2vec2_url(refresh=refresh, *args, **kwargs)
+
+
+def xls_r_1b(refresh=False, *args, **kwargs):
+    kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/xlsr2_960m_1000k.pt'
+    return wav2vec2_url(refresh=refresh, *args, **kwargs)
+
+
+def xls_r_2b(refresh=False, *args, **kwargs):
+    kwargs['ckpt'] = 'https://dl.fbaipublicfiles.com/fairseq/wav2vec/xlsr2_2B_1000k.pt'
     return wav2vec2_url(refresh=refresh, *args, **kwargs)

--- a/s3prl/upstream/wavlm/expert.py
+++ b/s3prl/upstream/wavlm/expert.py
@@ -39,6 +39,7 @@ class UpstreamExpert(UpstreamBase):
         self.cfg = WavLMConfig(checkpoint['cfg'])
         self.model = WavLM(self.cfg)
         self.model.load_state_dict(checkpoint['model'])
+        self.model.feature_grad_mult = 0.0
 
         if len(self.hooks) == 0:
             module_name = "self.model.encoder.layers"


### PR DESCRIPTION
### tested on PR

- train 1000 steps and report the validation

| model_name | PER |
| - | - |
| wav2vec2 | 7.81997 |
| xlsr_53 | 5.88189 |
| xls_r_300m | 7.265348 |

- wav2vec2 is compared with the original master on their extracted hidden_states' numerical values with `torch.allclose`