### PR TITLE
Fix doc strings for ASR related files

### DIFF
--- a/s3prl/dataio/corpus/librispeech.py
+++ b/s3prl/dataio/corpus/librispeech.py
@@ -127,6 +127,21 @@ class LibriSpeech(Corpus):
 
     @property
     def all_data(self):
+        """
+        Return all the data points in a dict of the format
+
+        .. code-block:: yaml
+
+            data_id1:
+                wav_path: (str) The waveform path
+                transcription: (str) The transcription
+                speaker: (str) The speaker name
+                gender: (str) The speaker's gender
+                corpus_split: (str) The split of corpus this sample belongs to
+
+            data_id2:
+                ...
+        """
         return self._data
 
     @property

--- a/s3prl/dataio/corpus/librispeech.py
+++ b/s3prl/dataio/corpus/librispeech.py
@@ -86,6 +86,17 @@ def _parse_spk_to_gender(speaker_file: Path) -> dict:
 
 
 class LibriSpeech(Corpus):
+    """LibriSpeech Corpus
+    Link: https://www.openslr.org/12
+
+    Args:
+        dataset_root (str): Path to LibriSpeech corpus directory.
+        n_jobs (int, optional): Number of jobs. Defaults to 4.
+        train_split (List[str], optional): Training splits. Defaults to ["train-clean-100"].
+        valid_split (List[str], optional): Validation splits. Defaults to ["dev-clean"].
+        test_split (List[str], optional): Testing splits. Defaults to ["test-clean"].
+    """
+
     def __init__(
         self,
         dataset_root: str,

--- a/s3prl/dataio/encoder/g2p.py
+++ b/s3prl/dataio/encoder/g2p.py
@@ -16,6 +16,8 @@ DEFAULT_LEXICON_URL = [
     "https://huggingface.co/datasets/s3prl/g2p/raw/main/lexicon/librispeech-lexicon-allothers-g2p.txt",
 ]
 
+__all__ = ["G2P"]
+
 
 def parse_lexicon(line: str) -> Tuple[str, List[str]]:
     line.replace("\t", " ")
@@ -45,18 +47,19 @@ def read_lexicon_files(file_list: List[str]) -> Dict[str, List[str]]:
 
 
 class G2P:
-    def __init__(self, file_list: List[str] = None):
-        """Grapheme-to-phoneme
+    """Grapheme-to-phoneme
 
-        Args:
-            file_list (List[str], optional): List of lexicon files. Defaults to None.
-        """
+    Args:
+        file_list (List[str], optional): List of lexicon files. Defaults to None.
+    """
+
+    def __init__(self, file_list: List[str] = None):
 
         if file_list is None:
             file_list = _urls_to_filepaths(*DEFAULT_LEXICON_URL)
         self.word2phone = read_lexicon_files(file_list)
 
-    def __call__(self, text: str) -> str:
+    def encode(self, text: str) -> str:
         """Converts grapheme-based sentences to phonemes
 
         Args:

--- a/s3prl/dataio/encoder/tokenizer.py
+++ b/s3prl/dataio/encoder/tokenizer.py
@@ -569,7 +569,7 @@ def default_phoneme_tokenizer() -> PhonemeTokenizer:
     """Returns a default LibriSpeech phoneme tokenizer.
 
     Returns:
-        PhonemeTokenizer: Vocabs are 71 phonemes
+        PhonemeTokenizer: Vocabs include 71 phonemes
     """
 
     return PhonemeTokenizer.load_from_file(vocab_list=PHONEME_VOCAB)

--- a/s3prl/dataio/encoder/tokenizer.py
+++ b/s3prl/dataio/encoder/tokenizer.py
@@ -28,6 +28,18 @@ PHONEME_VOCAB = "SIL SPN AA0 AA1 AA2 AE0 AE1 AE2 AH0 AH1 AH2 AO0 AO1 AO2 AW0 AW1
 translator = str.maketrans('ÁÃÄÅÆÇÈÉÊËÍÏÐÒÓÔÖØÚÛĘŃŌŞŪ"', "AAAAACEEEEIIDOOOOOUUENOSU ")
 
 
+__all__ = [
+    "CharacterTokenizer",
+    "CharacterSlotTokenizer",
+    "SubwordTokenizer",
+    "SubwordSlotTokenizer",
+    "WordTokenizer",
+    "PhonemeTokenizer",
+    "load_tokenizer",
+    "default_phoneme_tokenizer",
+]
+
+
 class Tokenizer:
     def __init__(self):
         super().__init__()

--- a/s3prl/dataio/encoder/vocabulary.py
+++ b/s3prl/dataio/encoder/vocabulary.py
@@ -13,6 +13,8 @@ from typing import List, Union
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["generate_basic_vocab", "generate_subword_vocab", "generate_vocab"]
+
 
 def generate_basic_vocab(
     mode: str,

--- a/s3prl/dataset/common_pipes.py
+++ b/s3prl/dataset/common_pipes.py
@@ -323,8 +323,8 @@ class Phonemize(DataPipe):
     g2p_name: str = "g2p"
     tokenizer_name: str = "tokenizer"
 
-    def grapheme2phoneme(self, g2p: Callable, text: str) -> str:
-        return g2p(text)
+    def grapheme2phoneme(self, g2p: G2P, text: str) -> str:
+        return g2p.encode(text)
 
     def encode_text(self, tokenizer: Tokenizer, text: str) -> torch.LongTensor:
         return torch.LongTensor(tokenizer.encode(text))

--- a/s3prl/nn/pooling.py
+++ b/s3prl/nn/pooling.py
@@ -58,7 +58,7 @@ class TemporalStatisticsPooling(nn.Module):
     """
     TemporalStatisticsPooling
     Paper: X-vectors: Robust DNN Embeddings for Speaker Recognition
-    Link： http://www.danielpovey.com/files/2018_icassp_xvectors.pdf
+    Link: http://www.danielpovey.com/files/2018_icassp_xvectors.pdf
     """
 
     def __init__(self, input_size: int):
@@ -97,7 +97,7 @@ class SelfAttentivePooling(nn.Module):
     """
     SelfAttentivePooling
     Paper: Self-Attentive Speaker Embeddings for Text-Independent Speaker Verification
-    Link： https://danielpovey.com/files/2018_interspeech_xvector_attention.pdf
+    Link: https://danielpovey.com/files/2018_interspeech_xvector_attention.pdf
     """
 
     def __init__(self, input_size: int):

--- a/s3prl/nn/rnn.py
+++ b/s3prl/nn/rnn.py
@@ -55,6 +55,20 @@ def downsample(
 
 
 class RNNLayer(nn.Module):
+    """RNN Layer
+
+    Args:
+        input_size (int): Input size.
+        hidden_size (int): Hidden size.
+        module (str): RNN module (RNN, GRU, LSTM)
+        dropout (float, optional): Dropout rate. Defaults to 0.0.
+        bidirectional (bool, optional): Bidirectional. Defaults to False.
+        proj (bool, optional): Projection layer. Defaults to False.
+        layer_norm (bool, optional): Layer normalization. Defaults to False.
+        sample_rate (int, optional): Downsampling rate. Defaults to 1.
+        sample_style (str, optional): Downsampling style (**drop** or **concat**). Defaults to "drop".
+    """
+
     def __init__(
         self,
         input_size: int,
@@ -67,19 +81,7 @@ class RNNLayer(nn.Module):
         sample_rate: int = 1,
         sample_style: str = "drop",
     ):
-        """RNN Layer
 
-        Args:
-            input_size (int): Input size.
-            hidden_size (int): Hidden size.
-            module (str): RNN module (RNN, GRU, LSTM)
-            dropout (float, optional): Dropout rate. Defaults to 0.0.
-            bidirectional (bool, optional): Bidirectional. Defaults to False.
-            proj (bool, optional): Projection layer. Defaults to False.
-            layer_norm (bool, optional): Layer normalization. Defaults to False.
-            sample_rate (int, optional): Downsampling rate. Defaults to 1.
-            sample_style (str, optional): Downsampling style (**drop** or **concat**). Defaults to "drop".
-        """
         super().__init__()
         self._insize = input_size
 
@@ -165,6 +167,21 @@ class RNNLayer(nn.Module):
 
 
 class RNNEncoder(AbsFrameModel):
+    """RNN Encoder for sequence to sequence modeling, e.g., ASR.
+
+    Args:
+        input_size (int): Input size.
+        output_size (int): Output size.
+        module (str, optional): RNN module type. Defaults to "LSTM".
+        hidden_size (List[int], optional): Hidden sizes for each layer. Defaults to [1024].
+        dropout (List[float], optional): Dropout rates for each layer. Defaults to [0.0].
+        layer_norm (List[bool], optional): Whether to use layer norm for each layer. Defaults to [False].
+        proj (List[bool], optional): Whether to use projection for each layer. Defaults to [True].
+        sample_rate (List[int], optional): Downsample rates for each layer. Defaults to [1].
+        sample_style (str, optional): Downsample style ("drop" or "concat"). Defaults to "drop".
+        bidirectional (bool, optional): Whether RNN layers are bidirectional. Defaults to False.
+    """
+
     def __init__(
         self,
         input_size: int,
@@ -179,20 +196,6 @@ class RNNEncoder(AbsFrameModel):
         sample_style: str = "drop",
         bidirectional: bool = False,
     ):
-        """RNN Encoder for sequence to sequence modeling, e.g., ASR.
-
-        Args:
-            input_size (int): Input size.
-            output_size (int): Output size.
-            module (str, optional): RNN module type. Defaults to "LSTM".
-            hidden_size (List[int], optional): Hidden sizes for each layer. Defaults to [1024].
-            dropout (List[float], optional): Dropout rates for each layer. Defaults to [0.0].
-            layer_norm (List[bool], optional): Whether to use layer norm for each layer. Defaults to [False].
-            proj (List[bool], optional): Whether to use projection for each layer. Defaults to [True].
-            sample_rate (List[int], optional): Downsample rates for each layer. Defaults to [1].
-            sample_style (str, optional): Downsample style ("drop" or "concat"). Defaults to "drop".
-            bidirectional (bool, optional): Whether RNN layers are bidirectional. Defaults to False.
-        """
         super().__init__()
         self._input_size = input_size
         self._output_size = output_size

--- a/s3prl/task/speech2text_ctc_task.py
+++ b/s3prl/task/speech2text_ctc_task.py
@@ -34,7 +34,14 @@ __all__ = [
 ]
 
 
-class Speech2TextCTCExample(torch.nn.Module):
+class Speech2TextCTCExample(nn.Module):
+    """An example speech-to-text task with CTC objective
+
+    Args:
+        input_size (int, optional): Input size. Defaults to 3.
+        output_size (int, optional): Output size. Defaults to 4.
+    """
+
     def __init__(self, input_size=3, output_size=4):
         super().__init__()
         self._input_size = input_size
@@ -64,6 +71,17 @@ class Speech2TextCTCExample(torch.nn.Module):
 
 
 class Speech2TextCTCTask(Task):
+    """Speech-to-text task with CTC objective
+
+    Args:
+        model (Speech2TextCTCExample)
+        tokenizer (Tokenizer): Text tokenizer.
+        decoder (Union[BeamDecoder, dict], optional):
+            Beam decoder or decoder's config. Defaults to None.
+        log_metrics (List[str], optional):
+            Metrics to be logged. Defaults to ["cer", "wer"].
+    """
+
     def __init__(
         self,
         model: torch.nn.Module,
@@ -71,17 +89,6 @@ class Speech2TextCTCTask(Task):
         decoder: Union[BeamDecoder, dict] = None,
         log_metrics: List[str] = ["cer", "wer"],
     ) -> None:
-        """Speech-to-text task with CTC objective
-
-        Args:
-            model (Speech2TextCTCExample)
-            tokenizer (Tokenizer): Text tokenizer.
-            decoder (Union[BeamDecoder, dict], optional):
-                Beam decoder or decoder's config. Defaults to None.
-            log_metrics (List[str], optional):
-                Metrics to be logged. Defaults to ["cer", "wer"].
-        """
-
         super().__init__()
         self.model = model
 

--- a/test/test_g2p.py
+++ b/test/test_g2p.py
@@ -6,5 +6,5 @@ from s3prl.dataio.encoder.g2p import G2P
 def test_g2p():
     g2p = G2P()
     char_sent = "HELLO WORLD"
-    phn_sent = g2p(char_sent)
+    phn_sent = g2p.encode(char_sent)
     logging.info(phn_sent)


### PR DESCRIPTION
Fix doc strings for ASR related files, including:
- moving doc strings out of `__init__`
- adding `__all__` to some files
- change `G2P.__call__` to `G2P.encode`