### PR TITLE
Change wavlm unispeech link

### DIFF
--- a/s3prl/upstream/unispeech_sat/hubconf.py
+++ b/s3prl/upstream/unispeech_sat/hubconf.py
@@ -49,13 +49,10 @@ def unispeech_sat_base(refresh=False, *args, **kwargs):
     The Base model
         refresh (bool): whether to download ckpt/config again if existed
     """
-    # Azure Storage
     kwargs[
         "ckpt"
-    ] = "https://msranlcmtteamdrive.blob.core.windows.net/share/unispeech-sat/UniSpeech-SAT-Base.pt?sv=2020-08-04&st=2021-11-26T10%3A09%3A40Z&se=2022-11-27T10%3A09%3A00Z&sr=b&sp=r&sig=iHQ9HTPwajdzHPVXAsYWeYFbDQ4a%2BmVdpL9BpoKBa5g%3D"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/unispeech_sat_base.pt"
 
-    # Google Drive
-    # kwargs["ckpt"] = "https://drive.google.com/u/1/uc?id=1j6WMIdOIu_GMtRVINTqjxMsHq_cf98_b&export=download"
     return unispeech_sat_url(refresh=refresh, *args, **kwargs)
 
 
@@ -64,13 +61,10 @@ def unispeech_sat_base_plus(refresh=False, *args, **kwargs):
     The Base-Plus model
         refresh (bool): whether to download ckpt/config again if existed
     """
-    # Azure Storage
     kwargs[
         "ckpt"
-    ] = "https://msranlcmtteamdrive.blob.core.windows.net/share/unispeech-sat/UniSpeech-SAT-Base+.pt?sv=2020-08-04&st=2021-11-26T10%3A10%3A25Z&se=2022-11-27T10%3A10%3A00Z&sr=b&sp=r&sig=plC0%2BNmN7Q18RgdmHBIrEBK2IuMUSW%2F0AnLqleO2JX8%3D"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/unispeech_sat_base_plus.pt"
 
-    # Google Drive
-    # kwargs["ckpt"] = "https://drive.google.com/u/1/uc?id=1AymTVpum41nMlGQLqheRO_kaFKbxZvvV&export=download"
     return unispeech_sat_url(refresh=refresh, *args, **kwargs)
 
 
@@ -79,11 +73,8 @@ def unispeech_sat_large(refresh=False, *args, **kwargs):
     The Large model
         refresh (bool): whether to download ckpt/config again if existed
     """
-    # Azure Storage
     kwargs[
         "ckpt"
-    ] = "https://msranlcmtteamdrive.blob.core.windows.net/share/unispeech-sat/UniSpeech-SAT-Large.pt?sv=2020-08-04&st=2021-11-26T10%3A10%3A59Z&se=2022-11-27T10%3A10%3A00Z&sr=b&sp=r&sig=U7cExvz%2Bt4mVGdN9mdRQ0U%2FodUuS25wGcHtoUmk2Dd4%3D"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/unispeech_sat_large.pt"
 
-    # Google Drive
-    # kwargs["ckpt"] = "https://drive.google.com/u/1/uc?id=15FR4Y1vohoVnOTc_ob7K9OUn0L1KrV1A&export=download"
     return unispeech_sat_url(refresh=refresh, *args, **kwargs)

--- a/s3prl/upstream/wavlm/hubconf.py
+++ b/s3prl/upstream/wavlm/hubconf.py
@@ -47,13 +47,10 @@ def wavlm_base(refresh=False, *args, **kwargs):
     The Base model
         refresh (bool): whether to download ckpt/config again if existed
     """
-    # Azure Storage
     kwargs[
         "ckpt"
-    ] = "https://msranlcmtteamdrive.blob.core.windows.net/share/wavlm/WavLM-Base.pt?sv=2020-04-08&st=2021-11-05T00%3A35%3A31Z&se=2022-11-06T00%3A35%3A00Z&sr=b&sp=r&sig=JljnRVzyHY6AjHzhVmHV5KyQQCvvGfgp9D2M02oGJBU%3D"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/wavlm_base.pt"
 
-    # Google Drive
-    # kwargs["ckpt"] = "https://drive.google.com/u/0/uc?id=19-C7SMQvEFAYLG5uc47NX_MY03JCbI4x&export=download"
     return wavlm_url(refresh=refresh, *args, **kwargs)
 
 
@@ -66,8 +63,6 @@ def wavlm_base_plus(refresh=False, *args, **kwargs):
         "ckpt"
     ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/wavlm_base_plus.pt"
 
-    # Google Drive
-    # kwargs["ckpt"] = "https://drive.google.com/u/1/uc?id=1PlbT_9_B4F9BsD_ija84sUTVw7almNX8&export=download"
     return wavlm_url(refresh=refresh, *args, **kwargs)
 
 
@@ -76,11 +71,8 @@ def wavlm_large(refresh=False, *args, **kwargs):
     The Large model
         refresh (bool): whether to download ckpt/config again if existed
     """
-    # Azure Storage
     kwargs[
         "ckpt"
-    ] = "https://msranlcmtteamdrive.blob.core.windows.net/share/wavlm/WavLM-Large.pt?sv=2020-08-04&st=2021-11-22T10%3A03%3A53Z&se=2022-11-23T10%3A03%3A00Z&sr=b&sp=r&sig=3kB8dwTCyIS8YQ7gW5oXmDrXV%2FAaLmoxBS37oPpFsz4%3D"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/wavlm_large.pt"
 
-    # Google Drive
-    # kwargs["ckpt"] = "https://drive.google.com/u/1/uc?id=1p8nbj16b7YA16sqPZ4E0JUL-oIDUBGwU&export=download"
     return wavlm_url(refresh=refresh, *args, **kwargs)

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -193,7 +193,7 @@ def test_common_upstream(name):
 
 @pytest.mark.upstream
 @pytest.mark.slow
-def test_upstream_with_extracted(upstream_names: str = None):
+def test_upstream_with_extracted(upstream_names: str):
     _prepare_sample_hidden_states()
 
     if upstream_names is not None:
@@ -223,7 +223,7 @@ def test_upstream_with_extracted(upstream_names: str = None):
 
 @pytest.mark.upstream
 @pytest.mark.slow
-def test_upstream_forward_backward(upstream_names: str = None):
+def test_upstream_forward_backward(upstream_names: str):
     if upstream_names is not None:
         options = upstream_names.split(",")
     else:


### PR DESCRIPTION
the link on Amazon Asure might be easily deprecated, while the gdrive links provided by the official authors are not suitable since gdrive will blocks automatic downloading after several trials. Hence, moving wavlm & unispeech model weights to huggingface hub and change the links in the `hubconf.py`