### PR TITLE
fix doc toc

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,6 @@ pre-commit
 flake8 ==3.9.2
 black ==22.3.0
 isort ==5.10.1
-sphinx
+sphinx ==5.1.1  # follow https://github.com/sphinx-doc/sphinx/issues/6316
 furo
 importlib_metadata <5.0  # required by flake8


### PR DESCRIPTION
sphinx 5.2.0 introduce to list all the documented objects in the toc.
However, the style is not satisfactory and this feature can't be easily disabledfor `autoclass` users.
Hence, fix the sphinx version to `5.1.1` as a temporary fix.