### PR TITLE
Add new wav2vec2 entries: s2st-es-voxpopuli

### DIFF
--- a/s3prl/upstream/wav2vec2/hubconf.py
+++ b/s3prl/upstream/wav2vec2/hubconf.py
@@ -4,7 +4,7 @@
 """*********************************************************************************************"""
 #   FileName     [ upstream/wav2vec2/hubconf.py ]
 #   Synopsis     [ the wav2vec 2.0 torch hubconf ]
-#   Author       [ S3PRL / Kushal Lakhotia]
+#   Author       [ S3PRL / Kushal Lakhotia ]
 """*********************************************************************************************"""
 
 import logging
@@ -176,4 +176,26 @@ def wav2vec2_large_voxpopuli_100k(refresh=False, legacy=False, **kwargs):
         kwargs[
             "ckpt"
         ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/wav2vec2_large_100k.pt"
+    return wav2vec2_custom(refresh=refresh, legacy=legacy, **kwargs)
+
+
+def wav2vec2_base_s2st_es_voxpopuli(refresh=False, legacy=False, **kwargs):
+    kwargs[
+        "ckpt"
+    ] = "https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/w2v2/es/transformer_B.pt"
+    if not legacy:
+        kwargs[
+            "ckpt"
+        ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/wav2vec2-base-s2st-es-voxpopuli.pt"
+    return wav2vec2_custom(refresh=refresh, legacy=legacy, **kwargs)
+
+
+def wav2vec2_large_s2st_es_voxpopuli(refresh=False, legacy=False, **kwargs):
+    kwargs[
+        "ckpt"
+    ] = "https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/w2v2/es/transformer_L.pt"
+    if not legacy:
+        kwargs[
+            "ckpt"
+        ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/wav2vec2-large-s2st-es-voxpopuli.pt"
     return wav2vec2_custom(refresh=refresh, legacy=legacy, **kwargs)


### PR DESCRIPTION
PR for the issue https://github.com/s3prl/s3prl/issues/434.
The following two models are added to the hub:
[wav2vec2-base trained on ES with Voxpopuli](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/w2v2/es/transformer_B.pt) ([Reference page](https://github.com/facebookresearch/fairseq/blob/main/examples/speech_to_speech/docs/enhanced_direct_s2st_discrete_units.md))
[wav2vec2-large trained on ES with Voxpopuli](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/w2v2/es/transformer_L.pt) ([Reference page](https://github.com/facebookresearch/fairseq/blob/main/examples/speech_to_speech/docs/enhanced_direct_s2st_discrete_units.md))

Currently, the second one (wav2vec2-large) has a broken download link, 
so the pre-trained model is not yet converted to our new torch checkpoints.
The first one (wav2vec2-base) is converted and waiting for upload.