### PR TITLE
Update Flashlight Text/Sequence repo sources

### DIFF
--- a/s3prl/downstream/asr/config.yaml
+++ b/s3prl/downstream/asr/config.yaml
@@ -54,7 +54,7 @@ downstream_expert:
     zero_infinity: True
 
     decoder_args:
-      # See https://github.com/facebookresearch/flashlight/blob/master/flashlight/lib/text/decoder/LexiconDecoder.h#L20
+      # See https://github.com/flashlight/text/blob/main/flashlight/lib/text/decoder/LexiconDecoder.h#L20-L30
       # for what the options mean. Python binding exposes the same options from C++.
       # KenLM is a fast LM query implementation, and it can be powered by:
       # 1. official LibriSpeech 4-gram LM: the 4-gram.arpa file on http://www.openslr.org/11

--- a/s3prl/downstream/asr/w2l_decoder.py
+++ b/s3prl/downstream/asr/w2l_decoder.py
@@ -39,7 +39,7 @@ try:
     )
 except:
     warnings.warn(
-        "flashlight python bindings are required to use this functionality. Please install from https://github.com/facebookresearch/flashlight/tree/master/bindings/python"
+        "flashlight python bindings are required to use this functionality. Please install from https://github.com/flashlight/text and https://github.com/flashlight/sequence"
     )
     LM = object
     LMState = object

--- a/s3prl/downstream/docs/superb.md
+++ b/s3prl/downstream/docs/superb.md
@@ -166,10 +166,9 @@ Installing all the dependencies right could be quite complicated. Note that the 
 ##### I. Prepare Decoding Environment
 
 1. Install [KenLM](https://github.com/kpu/kenlm)
-    - Please follow the official installation instructions of KenLM instead of the one documented in flashlight or wav2letter du to some known issues.
+    - Please follow the official installation instructions of KenLM.
 
-2. Install [flashlight python bindings](https://github.com/flashlight/flashlight/blob/master/bindings/python/README.md)
-    - Only the **python bindings** is required instead of the entire flashlight toolkit
+2. Install [Flashlight Text bindings](https://github.com/flashlight/text) and [Flashlight Sequence bindings](https://github.com/flashlight/sequence/).
 
 3. Download LibriSpeech official 4-gram LM
     - https://www.openslr.org/resources/11/4-gram.arpa.gz

--- a/s3prl/nn/beam_decoder.py
+++ b/s3prl/nn/beam_decoder.py
@@ -76,7 +76,7 @@ class BeamDecoder(object):
             )
 
         except ImportError:
-            logger.error(f"Please install flashlight to enable {__class__.__name__}")
+            logger.error(f"Please install Flashlight Text from https://github.com/flashlight/text to enable {__class__.__name__}")
             raise
 
         if token == "":


### PR DESCRIPTION
Fixes https://github.com/s3prl/s3prl/issues/407. The beam search decoder in Flashlight has moved to https://github.com/flashlight/text, and Viterbi algorithm implementations have moved to https://github.com/flashlight/sequence.

Update logs and documentation to correctly point to those repos.