### PR TITLE
ContentVec support

### DIFF
--- a/s3prl/upstream/hubert/hubconf.py
+++ b/s3prl/upstream/hubert/hubconf.py
@@ -128,3 +128,24 @@ def mhubert_base_vp_en_es_fr_it3(refresh=False, **kwds):
         "ckpt"
     ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/mhubert_base_vp_en_es_fr_it3.pt"
     return hubert_custom(refresh=refresh, **kwds)
+
+
+def contentvec(refresh=False, **kwds):
+    kwds[
+        "ckpt"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/contentvec_km100.pt"
+    return hubert_custom(refresh=refresh, **kwds)
+
+
+def contentvec_km100(refresh=False, **kwds):
+    kwds[
+        "ckpt"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/contentvec_km100.pt"
+    return hubert_custom(refresh=refresh, **kwds)
+
+
+def contentvec_km500(refresh=False, **kwds):
+    kwds[
+        "ckpt"
+    ] = "https://huggingface.co/s3prl/converted_ckpts/resolve/main/contentvec_km500.pt"
+    return hubert_custom(refresh=refresh, **kwds)


### PR DESCRIPTION
Paper: [ContentVec: An Improved Self-Supervised Speech Representation by Disentangling Speakers](https://arxiv.org/abs/2204.09224)
Code: https://github.com/auspicious3000/contentvec

Models: (the default is `contentvec_km100`)
- [contentvec_km100](https://ibm.box.com/s/t76fff0dciyjqt1db03y48323qp99bg9)
- [contentvec_km500](https://ibm.box.com/s/z1wgl1stco8ffooyatzdwsqn2psd9lrr)

The model architecture is identical to HuBERT Base, so only `s3prl/upstream/hubert/hubconf.py` is modified.