### PR TITLE
Fix BYOL-A implementation

### DIFF
--- a/s3prl/upstream/byol_a/README.md
+++ b/s3prl/upstream/byol_a/README.md
@@ -1,0 +1,50 @@
+# BYOL-A upstream model for SUPERB
+
+- BYOL-A reqires normalization statistics pre-computed for each downstream tasks.
+- Evaluate BYOL-A in two steps. First, calculate statistics, then, train and test using the computed stats.
+
+## Using BYOL-A on SUPERB
+
+### 1. Pre-compute statistics.
+
+The followings explain using a downstream task `voxceleb1`.
+
+    python run_downstream.py -m train -n byol_a_2048_calcnorm_1 -u byol_a_2048_calcnorm -d voxceleb1
+
+This will output:
+
+    ** Running Norm has finished updates over 10000 times, using the following stats from now on. ***
+    mean=-8.907230377197266, std=4.892485618591309
+    *** Please use these statistics in your model. EXIT... ***
+
+These `-8.907230377197266` and `4.8924856` are the statistics for the `voxceleb1`. We add a function for using these values in the `hubconf.py`.
+
+```python
+def byol_a_2048_vc1(refresh=False, **kwds):
+    """BYOL-A d=2048 for voxceleb1."""
+    return _byol_a_2048(norm_mean=-8.9072303, norm_std=4.8924856, **kwds)
+```
+
+### 2. Evaluating on a downstream task
+
+For the `voxceleb1`, we use the `byol_a_2048_vc1` to train and test.
+
+    python run_downstream.py -m train -n byol_a_2048_vc1_1 -u byol_a_2048_vc1 -d voxceleb1
+    python run_downstream.py -m train -n byol_a_2048_vc1_1 -u byol_a_2048_vc1 -d voxceleb1 -o "config.optimizer.lr=1e-2"
+
+The following will test the trained model.
+
+    python run_downstream.py -m evaluate -n byol_a_2048_vc1_1 -d voxceleb1 -e result/downstream/byol_a_2048_vc1_1/dev-best.ckpt
+
+
+## Examples
+
+### PR
+
+    pip install editdistance
+
+    python run_downstream.py -m train -n byol_a_2048_pr_1 -u byol_a_2048_LS -d ctc -c downstream/ctc/libriphone.yaml -o "config.optimizer.lr=1e-3"
+    CUDA_VISIBLE_DEVICES=1 python run_downstream.py -m train -n byol_a_2048_pr_1 -u byol_a_2048_LS -d ctc -c downstream/ctc/libriphone.yaml -o "config.optimizer.lr=1e-3"
+
+    CUDA_VISIBLE_DEVICES=1 python run_downstream.py -m evaluate -n byol_a_2048_pr_1 -d ctc -c downstream/ctc/libriphone.yaml -e result/downstream/byol_a_2048_pr_1/dev-best.ckpt
+

--- a/s3prl/upstream/byol_a/byol_a.py
+++ b/s3prl/upstream/byol_a/byol_a.py
@@ -367,7 +367,9 @@ class RunningNorm(nn.Module):
             self.std = torch.clamp(self.ema_var.std(), torch.finfo().eps, torch.finfo().max)
         elif not self.reported:
             self.reported = True
-            print(f'*** Running Norm has finished updates over {self.max_update} times, using the following stats from now on. ***\n  mean={self.mean}, std={self.std}\n\n')
+            print(f'*** Running Norm has finished updates over {self.max_update} times, using the following stats from now on. ***\n  mean={float(self.mean.view(-1))}, std={float(self.std.view(-1))}\n')
+            print(f'*** Please use these statistics in your BYOL-A. EXIT... ***\n')
+            exit(-1)
         return ((image - self.mean) / self.std)
 
     def __repr__(self):

--- a/s3prl/upstream/byol_a/byol_a.py
+++ b/s3prl/upstream/byol_a/byol_a.py
@@ -20,6 +20,30 @@ from pathlib import Path
 import torch
 import yaml
 from torch import nn
+import nnAudio.features
+
+
+class LogMelSpectrogram:
+    def __init__(self):
+        self.to_melspec = nnAudio.features.MelSpectrogram(
+            sr=16000,
+            n_fft=1024,
+            win_length=1024,
+            hop_length=160,
+            n_mels=64,
+            fmin=60,
+            fmax=7800,
+            center=True,
+            power=2,
+            verbose=False,
+        )
+
+    def to(self, device):
+        self.to_melspec = self.to_melspec.to(device)
+
+    def __call__(self, wav):
+        x = (self.to_melspec(wav) + torch.finfo(torch.float).eps).log()
+        return x # [B, F, T]
 
 
 def load_yaml_config(path_to_config):
@@ -54,36 +78,35 @@ class PrecomputedNorm(nn.Module):
         return format_string
 
 
-class NetworkCommonMixIn:
+class NetworkCommonMixIn():
     """Common mixin for network definition."""
 
-    def load_weight(self, weight_file, device):
+    def load_weight(self, weight_file, device, state_dict=None, key_check=True):
         """Utility to load a weight file to a device."""
 
-        state_dict = torch.load(weight_file, map_location=device)
-        if "state_dict" in state_dict:
-            state_dict = state_dict["state_dict"]
+        state_dict = state_dict or torch.load(weight_file, map_location=device)
+        if 'state_dict' in state_dict:
+            state_dict = state_dict['state_dict']
         # Remove unneeded prefixes from the keys of parameters.
-        weights = {}
-        for k in state_dict:
-            m = re.search(r"(^fc\.|\.fc\.|^features\.|\.features\.)", k)
-            if m is None:
-                continue
-            new_k = k[m.start() :]
-            new_k = new_k[1:] if new_k[0] == "." else new_k
-            weights[new_k] = state_dict[k]
+        if key_check:
+            weights = {}
+            for k in state_dict:
+                m = re.search(r'(^fc\.|\.fc\.|^features\.|\.features\.)', k)
+                if m is None: continue
+                new_k = k[m.start():]
+                new_k = new_k[1:] if new_k[0] == '.' else new_k
+                weights[new_k] = state_dict[k]
+        else:
+            weights = state_dict
         # Load weights and set model to eval().
         self.load_state_dict(weights)
         self.eval()
-        logging.info(
-            f"Using audio embbeding network pretrained weight: {Path(weight_file).name}"
-        )
+        logging.info(f'Using audio embbeding network pretrained weight: {Path(weight_file).name}')
         return self
 
     def set_trainable(self, trainable=False):
         for p in self.parameters():
-            if p.requires_grad:
-                p.requires_grad = trainable
+            p.requires_grad = trainable
 
 
 class AudioNTT2020Task6(nn.Module, NetworkCommonMixIn):
@@ -138,3 +161,216 @@ class AudioNTT2020(AudioNTT2020Task6):
         x = x1 + x2
         assert x.shape[1] == self.d and x.ndim == 2
         return x
+
+
+class AudioNTT2020Task6X(nn.Module, NetworkCommonMixIn):
+    """A variant of DCASE2020 Task6 NTT Solution Audio Embedding Network.
+    Enabeld to return features by layers.
+    """
+
+    def __init__(self, n_mels, d):
+        super().__init__()
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(1, 64, 3, stride=1, padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.MaxPool2d(2, stride=2),
+        )
+        self.conv2 = nn.Sequential(
+            nn.Conv2d(64, 64, 3, stride=1, padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.MaxPool2d(2, stride=2),
+        )
+        self.conv3 = nn.Sequential(
+            nn.Conv2d(64, 64, 3, stride=1, padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.MaxPool2d(2, stride=2),
+        )
+        self.fc1 = nn.Sequential(
+            nn.Linear(64 * (n_mels // (2**3)), d),
+            nn.ReLU(),
+        )
+        self.fc2 = nn.Sequential(
+            nn.Dropout(p=0.3),
+            nn.Linear(d, d),
+            nn.ReLU(),
+        )
+        self.d = d
+        self.n_feature_layer = 5
+
+    def forward(self, x, layered=False):
+        def reshape_conv_feature(v):
+            B, CH, F, T = v.shape
+            v = v.permute(0, 3, 1, 2).reshape(B, T, CH*F)
+            # pad 0 at the end to make the feature dimension -> self.d
+            if v.shape[-1] < self.d:
+                v = torch.nn.functional.pad(v, (0, self.d - v.shape[-1]), 'constant', 0.0)
+            # average to the target length
+            while v.shape[1] > target_t:
+                ## when odd time frames -> average last two frames into one frame
+                if v.shape[1] % 2 == 1:
+                    v = torch.cat([v[:, :-2], v[:, -2:].mean(1, keepdim=True)], axis=1)
+                # [B, T, D] -> [B, T/2, D]
+                T = v.shape[1]
+                v = v.reshape(B, T//2, 2, v.shape[-1]).mean(2) # average adjoining two time frame features.
+            return v
+
+        target_t = x.shape[-1] // 8
+        features = []
+        x = self.conv1(x)  # (batch, ch, mel, time)
+        features.append(reshape_conv_feature(x))
+        x = self.conv2(x)
+        features.append(reshape_conv_feature(x))
+        x = self.conv3(x)
+        features.append(reshape_conv_feature(x))
+        x = x.permute(0, 3, 2, 1)  # (batch, time, mel, ch)
+        B, T, D, C = x.shape
+        x = x.reshape((B, T, C * D))  # (batch, time, mel*ch)
+        x = self.fc1(x)
+        features.append(x)
+        x = self.fc2(x)
+        features.append(x)
+
+        if layered:
+            return torch.cat(features, dim=-1) # [B, T, 5*D]
+        return x # [B, T, D]
+
+    def by_layers(self, layered_features):
+        """Decompose layered features into the list of features for each layer."""
+        *B, LD = layered_features.shape
+        assert LD == self.n_feature_layer * self.d
+        layered_features = layered_features.reshape(*B, self.n_feature_layer, self.d)
+        layered_features = layered_features.permute(2, 0, 1, 3) if len(layered_features.shape) > 3 else layered_features.permute(1, 0, 2)
+        return [layered_features[l] for l in range(self.n_feature_layer)]
+
+    def load_weight(self, weight_file, device):
+        """Whapper function for loading BYOL-A pre-trained weights."""
+        namemap = {
+            'features.0': 'conv1.0', 'features.1': 'conv1.1',
+            'features.4': 'conv2.0', 'features.5': 'conv2.1',
+            'features.8': 'conv3.0', 'features.9': 'conv3.1',
+            'fc.0': 'fc1.0',
+            'fc.3': 'fc2.1',
+        }
+        state_dict = torch.load(weight_file, map_location=device)
+        new_dict = {}
+        # replace keys and remove 'num_batches_tracked'
+        for key in state_dict:
+            if 'num_batches_tracked' in key:
+                continue
+            new_key = key
+            for map_key in namemap:
+                if map_key in key:
+                    new_key = key.replace(map_key, namemap[map_key])
+                    break
+            new_dict[new_key] = state_dict[key]
+        return super().load_weight(weight_file, device, state_dict=new_dict, key_check=False)
+
+
+class AudioNTT2020X(AudioNTT2020Task6X):
+    """BYOL-A General Purpose Representation Network.
+    This is an extension of the DCASE 2020 Task 6 NTT Solution Audio Embedding Network.
+    Enabeld to return features by layers.
+
+    Examples:
+        model(x) -> returns sample-level features of [B, D].
+        model(x, layered=True) -> returns sample-level layered features of [B, 5*D]
+        model(x, layered=True, by_layers=True) -> returns sample-level features by layers as a list of [B, D] * 5
+    """
+
+    def __init__(self, n_mels=64, d=2048):
+        super().__init__(n_mels=n_mels, d=d)
+
+    def forward(self, x, layered=False, by_layers=False):
+        x = super().forward(x, layered=layered)
+        (x1, _) = torch.max(x, dim=1)
+        x2 = torch.mean(x, dim=1)
+        x = x1 + x2
+        if by_layers:
+            return self.by_layers(x)
+        return x
+
+
+class RunningMean:
+    """Running mean calculator for arbitrary axis configuration.
+    Borrowed from https://github.com/nttcslab/byol-a/blob/master/v2/byol_a2/augmentations.py#L147
+    """
+
+    def __init__(self, axis):
+        self.n = 0
+        self.axis = axis
+
+    def put(self, x):
+        # https://math.stackexchange.com/questions/106700/incremental-averageing
+        self.n += 1
+        if self.n == 1:
+            self.mu = x.mean(self.axis, keepdims=True)
+        else:
+            self.mu += (x.mean(self.axis, keepdims=True) - self.mu) / self.n
+
+    def __call__(self):
+        return self.mu
+
+    def __len__(self):
+        return self.n
+
+
+class RunningVariance:
+    """Calculate mean/variance of tensors online.
+    Thanks to https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+    Borrowed from https://github.com/nttcslab/byol-a/blob/master/v2/byol_a2/augmentations.py#L147
+    """
+
+    def __init__(self, axis, mean):
+        self.update_mean(mean)
+        self.s2 = RunningMean(axis)
+
+    def update_mean(self, mean):
+        self.mean = mean
+
+    def put(self, x):
+        self.s2.put((x - self.mean) **2)
+
+    def __call__(self):
+        return self.s2()
+
+    def std(self):
+        return self().sqrt()
+
+
+class RunningNorm(nn.Module):
+    """Online Normalization using Running Mean/Std.
+    Borrowed from https://github.com/nttcslab/byol-a/blob/master/v2/byol_a2/augmentations.py#L147
+    This module will only update the statistics up to the specified number of epochs.
+    After the `max_update_epochs`, this will normalize with the last updated statistics.
+    Args:
+        epoch_samples: Number of samples in one epoch
+        max_update_epochs: Number of epochs to allow update of running mean/variance.
+        axis: Axis setting used to calculate mean/variance.
+    """
+
+    def __init__(self, epoch_samples, max_update_epochs=10, axis=[1, 2]):
+        super().__init__()
+        self.max_update = epoch_samples * max_update_epochs
+        self.ema_mean = RunningMean(axis)
+        self.ema_var = RunningVariance(axis, 0)
+        self.reported = False
+
+    def forward(self, image):
+        if len(self.ema_mean) < self.max_update:
+            self.ema_mean.put(image)
+            self.ema_var.update_mean(self.ema_mean())
+            self.ema_var.put(image)
+            self.mean = self.ema_mean()
+            self.std = torch.clamp(self.ema_var.std(), torch.finfo().eps, torch.finfo().max)
+        elif not self.reported:
+            self.reported = True
+            print(f'*** Running Norm has finished updates over {self.max_update} times, using the following stats from now on. ***\n  mean={self.mean}, std={self.std}\n\n')
+        return ((image - self.mean) / self.std)
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + f'(max_update={self.max_update},axis={self.ema_mean.axis})'
+        return format_string
+

--- a/s3prl/upstream/byol_a/byol_a.py
+++ b/s3prl/upstream/byol_a/byol_a.py
@@ -367,7 +367,7 @@ class RunningNorm(nn.Module):
             self.std = torch.clamp(self.ema_var.std(), torch.finfo().eps, torch.finfo().max)
         elif not self.reported:
             self.reported = True
-            print(f'*** Running Norm has finished updates over {self.max_update} times, using the following stats from now on. ***\n  mean={float(self.mean.view(-1))}, std={float(self.std.view(-1))}\n')
+            print(f'*** Running Norm has finished updates over {self.max_update} times, using the following stats from now on. ***\n  mean,std={float(self.mean.view(-1))},{float(self.std.view(-1))}\n')
             print(f'*** Please use these statistics in your BYOL-A. EXIT... ***\n')
             exit(-1)
         return ((image - self.mean) / self.std)

--- a/s3prl/upstream/byol_a/config.yaml
+++ b/s3prl/upstream/byol_a/config.yaml
@@ -20,6 +20,9 @@ bs: 256
 lr: 0.0003
 epochs: 100
 gpus: 1
+# Statistics to be set for each downstream task.
+norm_mean:
+norm_std:
 # Weight pathname for resuming training.
 resume:
 # Shape of loh-mel spectrogram [F, T].

--- a/s3prl/upstream/byol_a/expert.py
+++ b/s3prl/upstream/byol_a/expert.py
@@ -29,29 +29,18 @@ class UpstreamExpert(nn.Module):
         self,
         ckpt: str,
         model_config: str,
-        feature_d: int,
-        window_secs: float = 1024 / 16000,
-        stride_secs: float = 160 / 16000,
         norm_mean: float = None,  # Has to be a float value to continue training.
         norm_std: float = None,  # The same as above.
     ):
         super().__init__()
         config = load_yaml_config(model_config)
 
-        self.window_secs = window_secs
-        self.stride_secs = stride_secs
-        self.output_dim = feature_d
-        self.seg_input_length = len(
-            range(0, int(window_secs * SAMPLE_RATE), config.hop_length)
-        )
-        self.max_input_length = config.shape[-1]
-
         # Preprocessor and normalizer.
         self.to_logmelspec = LogMelSpectrogram()
         if norm_mean is None or norm_std is None:
-            # ** CAUTION **
-            # ** Please note that thi is for calculating statistics using RunningNorm and will exit in the middle of training. **
-            # ** CAUTION **
+            print('  ** CAUTION **')
+            print('  This is a run for calculating statistics of the downstream task using RunningNorm and will exit in the middle of training. **')
+            print('  ** CAUTION **')
             self.normalizer = RunningNorm(epoch_samples=10_000, max_update_epochs=1, axis=[0, 1, 2]) # Use single scalar mean/std values.
         else:
             print(f'*** Using normalization statistics: mean={norm_mean}, std={norm_std} ***')

--- a/s3prl/upstream/byol_a/expert.py
+++ b/s3prl/upstream/byol_a/expert.py
@@ -11,9 +11,9 @@ import logging
 
 import torch
 import torch.nn as nn
-import torchaudio
+from torch.nn.utils.rnn import pad_sequence
 
-from .byol_a import AudioNTT2020, PrecomputedNorm, load_yaml_config
+from .byol_a import load_yaml_config, LogMelSpectrogram, RunningNorm, AudioNTT2020Task6X
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +30,8 @@ class UpstreamExpert(nn.Module):
         ckpt: str,
         model_config: str,
         feature_d: int,
-        window_secs: float = 1.0,
-        stride_secs: float = 1.0,
+        window_secs: float = 1024 / 16000,
+        stride_secs: float = 160 / 16000,
     ):
         super().__init__()
         config = load_yaml_config(model_config)
@@ -42,30 +42,25 @@ class UpstreamExpert(nn.Module):
         self.seg_input_length = len(
             range(0, int(window_secs * SAMPLE_RATE), config.hop_length)
         )
+        self.max_input_length = config.shape[-1]
 
         # Preprocessor and normalizer.
-        self.to_melspec = torchaudio.transforms.MelSpectrogram(
-            sample_rate=config.sample_rate,
-            n_fft=config.n_fft,
-            win_length=config.win_length,
-            hop_length=config.hop_length,
-            n_mels=config.n_mels,
-            f_min=config.f_min,
-            f_max=config.f_max,
-        )
-        stats = [
-            -5.4919195,
-            5.0389895,
-        ]  # FIXME: should use downstream dataset statistics
-        self.normalizer = PrecomputedNorm(stats)
+        self.to_logmelspec = LogMelSpectrogram()
+        self.normalizer = RunningNorm(epoch_samples=10_000, max_update_epochs=1, axis=[0, 1, 2]) # Use single scalar mean/std values.
 
         # Load pretrained weights.
-        self.model = AudioNTT2020(d=feature_d)
-        self.model.load_weight(ckpt, device="cpu")
+        self.model = AudioNTT2020Task6X(d=config.feature_d, n_mels=config.n_mels)
+        self.model.load_weight(ckpt, device='cpu')
 
-    def get_downsample_rates(self, key: str = None) -> int:
-        return int(self.stride_secs * SAMPLE_RATE)
+    # Interface
+    def get_output_dim(self):
+        return self.output_dim
 
+    # Interface
+    def get_downsample_rates(self, key: str) -> int:
+        return 160 * 2**3 # hop_size x stride=2 for 3 layers
+
+    # Interface
     def forward(self, wavs):
         """
         Args:
@@ -80,50 +75,11 @@ class UpstreamExpert(nn.Module):
                 each feat is in torch.FloatTensor and already
                 put in the device assigned by command-line args
         """
-        wavs_len = [len(wav) for wav in wavs]
-        max_wav_len = max(wavs_len)
-        start_points = list(range(0, max_wav_len, int(self.stride_secs * SAMPLE_RATE)))
-        padded_max_wav_len = start_points[-1] + int(self.window_secs * SAMPLE_RATE)
-        padded_wavs = [
-            torch.cat([wav, wav.new_zeros(padded_max_wav_len - len(wav))])
-            for wav in wavs
-        ]
-
-        all_features = []
-        for start in start_points:
-            subwavs = [
-                wav[start : start + int(self.window_secs * SAMPLE_RATE)]
-                for wav in padded_wavs
-            ]
-            features = [
-                self.normalizer(
-                    (self.to_melspec(wav) + torch.finfo(torch.float).eps).log()
-                ).permute(1, 0)
-                for wav in subwavs
-            ]
-            features = torch.stack(
-                features, dim=0
-            )  # (batch_size, segment_seq_len, hiddqen_size)
-            all_features.append(features)
-
-        all_features = torch.stack(all_features, dim=0)
-        num_segment, batch_size, segment_seq_len, hidden_size = all_features.shape
-
-        flatten_features = all_features.reshape(-1, segment_seq_len, hidden_size)
-
-        repre = self.model(
-            flatten_features.transpose(1, 2).unsqueeze(1)
-        )  # repre: (num_segment * batch_size, hidden_size)
-        repre = repre.reshape(num_segment, batch_size, -1).transpose(
-            0, 1
-        )  # repre: (batch_size, num_segment, hidden_size)
-
-        trimmed_hs = []
-        for h in [repre]:
-            max_h_len = len(range(0, max_wav_len, self.get_downsample_rates()))
-            h = h[:, :max_h_len, :]
-            trimmed_hs.append(h)
-
+        self.to_logmelspec.to(wavs[0].device)
+        wavs = pad_sequence(wavs, batch_first=True)
+        features = self.normalizer(self.to_logmelspec(wavs)).unsqueeze(1) # (B, F, T) -> (B, 1, F, T)
+        layered_features = self.model.by_layers(self.model(features, layered=True)) # [(B, T, D)] x 5
         return {
-            "hidden_states": trimmed_hs,
+            "last_hidden_state": layered_features[-1],
+            "hidden_states": layered_features,
         }

--- a/s3prl/upstream/byol_a/hubconf.py
+++ b/s3prl/upstream/byol_a/hubconf.py
@@ -15,7 +15,7 @@ from .expert import UpstreamExpert as _UpstreamExpert
 DEFAULT_CONFIG_PATH = _Path(__file__).parent / "config.yaml"
 
 
-def byol_a_2048(refresh=False, **kwds):
+def _byol_a_2048(refresh=False, **kwds):
     ckpt = _urls_to_filepaths(
         "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d2048.pth",
         refresh=refresh,
@@ -24,7 +24,7 @@ def byol_a_2048(refresh=False, **kwds):
     return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 2048, **kwds)
 
 
-def byol_a_1024(refresh=False, **kwds):
+def _byol_a_1024(refresh=False, **kwds):
     ckpt = _urls_to_filepaths(
         "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d1024.pth",
         refresh=refresh,
@@ -33,10 +33,48 @@ def byol_a_1024(refresh=False, **kwds):
     return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 1024, **kwds)
 
 
-def byol_a_512(refresh=False, **kwds):
+def _byol_a_512(refresh=False, **kwds):
     ckpt = _urls_to_filepaths(
         "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d512.pth",
         refresh=refresh,
     )
     del kwds['ckpt'], kwds['model_config']
     return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 512, **kwds)
+
+
+### Add entries for each downstream tasks
+
+
+def byol_a_2048_calcnorm(refresh=False, **kwds):
+    """Calculate downstream task statistics using this model."""
+    return _byol_a_2048(**kwds)
+
+
+def byol_a_1024_calcnorm(refresh=False, **kwds):
+    """Calculate downstream task statistics using this model."""
+    return _byol_a_1024(**kwds)
+
+
+def byol_a_512_calcnorm(refresh=False, **kwds):
+    """Calculate downstream task statistics using this model."""
+    return _byol_a_512(**kwds)
+
+
+def byol_a_2048_LS(refresh=False, **kwds):
+    """BYOL-A d=2048 for LibriSpeech tasks."""
+    return _byol_a_2048(norm_mean=-8.5402, norm_std=4.5456, **kwds)
+
+
+def byol_a_1024_LS(refresh=False, **kwds):
+    """BYOL-A d=2048 for LibriSpeech tasks."""
+    return _byol_a_1024(norm_mean=-8.5402, norm_std=4.5456, **kwds)
+
+
+def byol_a_512_LS(refresh=False, **kwds):
+    """BYOL-A d=2048 for LibriSpeech tasks."""
+    return _byol_a_512(norm_mean=-8.5402, norm_std=4.5456, **kwds)
+
+
+def byol_a_2048_vc1(refresh=False, **kwds):
+    """BYOL-A d=2048 for voxceleb1."""
+    return _byol_a_2048(norm_mean=-8.9072303, norm_std=4.8924856, **kwds)

--- a/s3prl/upstream/byol_a/hubconf.py
+++ b/s3prl/upstream/byol_a/hubconf.py
@@ -20,6 +20,7 @@ def byol_a_2048(refresh=False, **kwds):
         "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d2048.pth",
         refresh=refresh,
     )
+    del kwds['ckpt'], kwds['model_config']  # to prevent duplicates in the kwds.
     return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 2048, **kwds)
 
 
@@ -28,6 +29,7 @@ def byol_a_1024(refresh=False, **kwds):
         "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d1024.pth",
         refresh=refresh,
     )
+    del kwds['ckpt'], kwds['model_config']
     return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 1024, **kwds)
 
 
@@ -36,4 +38,5 @@ def byol_a_512(refresh=False, **kwds):
         "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d512.pth",
         refresh=refresh,
     )
+    del kwds['ckpt'], kwds['model_config']
     return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 512, **kwds)

--- a/s3prl/upstream/byol_a/hubconf.py
+++ b/s3prl/upstream/byol_a/hubconf.py
@@ -15,66 +15,29 @@ from .expert import UpstreamExpert as _UpstreamExpert
 DEFAULT_CONFIG_PATH = _Path(__file__).parent / "config.yaml"
 
 
-def _byol_a_2048(refresh=False, **kwds):
-    ckpt = _urls_to_filepaths(
-        "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d2048.pth",
-        refresh=refresh,
-    )
-    del kwds['ckpt'], kwds['model_config']  # to prevent duplicates in the kwds.
-    return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 2048, **kwds)
+def _byol_a(refresh=False, **kwargs):
+    assert 'ckpt' in kwargs, '*** Please maks sure to set "-k your-checkpoint.pth".'
+    if 'model_config' not in kwargs or not kwargs['model_config']:
+        kwargs['model_config'] = DEFAULT_CONFIG_PATH
+    return _UpstreamExpert(**kwargs)
 
 
-def _byol_a_1024(refresh=False, **kwds):
-    ckpt = _urls_to_filepaths(
-        "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d1024.pth",
-        refresh=refresh,
-    )
-    del kwds['ckpt'], kwds['model_config']
-    return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 1024, **kwds)
-
-
-def _byol_a_512(refresh=False, **kwds):
-    ckpt = _urls_to_filepaths(
-        "https://github.com/nttcslab/byol-a/raw/master/pretrained_weights/AudioNTT2020-BYOLA-64x96d512.pth",
-        refresh=refresh,
-    )
-    del kwds['ckpt'], kwds['model_config']
-    return _UpstreamExpert(ckpt, DEFAULT_CONFIG_PATH, 512, **kwds)
-
-
-### Add entries for each downstream tasks
-
-
-def byol_a_2048_calcnorm(refresh=False, **kwds):
+def byol_a_calcnorm(refresh=False, **kwargs):
     """Calculate downstream task statistics using this model."""
-    return _byol_a_2048(**kwds)
+    return _byol_a(**kwargs)
 
 
-def byol_a_1024_calcnorm(refresh=False, **kwds):
-    """Calculate downstream task statistics using this model."""
-    return _byol_a_1024(**kwds)
-
-
-def byol_a_512_calcnorm(refresh=False, **kwds):
-    """Calculate downstream task statistics using this model."""
-    return _byol_a_512(**kwds)
-
-
-def byol_a_2048_LS(refresh=False, **kwds):
-    """BYOL-A d=2048 for LibriSpeech tasks."""
-    return _byol_a_2048(norm_mean=-8.5402, norm_std=4.5456, **kwds)
-
-
-def byol_a_1024_LS(refresh=False, **kwds):
-    """BYOL-A d=2048 for LibriSpeech tasks."""
-    return _byol_a_1024(norm_mean=-8.5402, norm_std=4.5456, **kwds)
-
-
-def byol_a_512_LS(refresh=False, **kwds):
-    """BYOL-A d=2048 for LibriSpeech tasks."""
-    return _byol_a_512(norm_mean=-8.5402, norm_std=4.5456, **kwds)
-
-
-def byol_a_2048_vc1(refresh=False, **kwds):
-    """BYOL-A d=2048 for voxceleb1."""
-    return _byol_a_2048(norm_mean=-8.9072303, norm_std=4.8924856, **kwds)
+def byol_a(refresh=False, *args, **kwargs):
+    """
+    kwargs['ckpt'] is expected in the format of "path-of-ckpt,dataset-mean,dataset-std".
+    """
+    assert 'ckpt' in kwargs, '*** Please maks sure to set "-k your-checkpoint.pth,dataset-mean,dataset-std".'
+    if kwargs['ckpt'] is None:
+        print('Set "-k your-checkpoint.pth,norm_mean,norm_std". Exit now.')
+        exit(-1)
+    ckpt, norm_mean, norm_std = kwargs['ckpt'].split(',')
+    kwargs['ckpt'] = ckpt
+    norm_mean, norm_std = float(norm_mean), float(norm_std)
+    print(' using checkpoint:', ckpt)
+    print(' normalization statistics:', norm_mean, norm_std)
+    return _byol_a(*args, norm_mean=norm_mean, norm_std=norm_std, **kwargs)

--- a/s3prl/upstream/byol_a/test_byola_norm.ipynb
+++ b/s3prl/upstream/byol_a/test_byola_norm.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test the calculation code for normalization statistics\n",
+    "\n",
+    "BYOL-A requires the normalization statistics, the average and standard deviation, precomputed using dataset samples.\n",
+    "\n",
+    "The implementation for the SUPERB uses running statistics; we test them.\n",
+    "\n",
+    "### Results\n",
+    "\n",
+    "The online calculation is confirmed to be close enough to the offline calculation, which the original BYOL-A does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import torchaudio\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# load the list of VoxCeleb1 files\n",
+    "vc1files = list(Path('/lab/data/voxceleb1/dev').rglob('*.wav'))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate normalization statistics *offline*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from byol_a import load_yaml_config, LogMelSpectrogram, RunningNorm\n",
+    "\n",
+    "config = load_yaml_config('./config.yaml')\n",
+    "to_logmelspec = LogMelSpectrogram()\n",
+    "normalizer = RunningNorm(epoch_samples=10_000, max_update_epochs=1, axis=[0, 1, 2]) # Use single scalar mean/std values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(torch.Size([1, 64, 8010000]), tensor(-8.9265), tensor(4.9163))"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "lms_list = []\n",
+    "for f in np.random.choice(vc1files, size=10000, replace=False):\n",
+    "    # load .wav data in the same way superb does.\n",
+    "    wav, sr = torchaudio.load(f) # https://github.com/s3prl/s3prl/blob/main/s3prl/downstream/voxceleb1/dataset.py#L106\n",
+    "    # pad in the same way we do in byol_a.py.\n",
+    "    wav = torch.nn.functional.pad(wav, (0, 128000))[..., :128000]\n",
+    "    # convert it to a log-mel spectrogram as a batch of single file.\n",
+    "    lms = to_logmelspec(wav[None, ...])\n",
+    "    lms_list.append(lms)\n",
+    "\n",
+    "lms_list = torch.cat(lms_list, dim=2)\n",
+    "lms_list.shape, lms_list.mean(), lms_list.std()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate normalization statistics *online*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "runnorm = RunningNorm(epoch_samples=10000, max_update_epochs=1, axis=[0, 1, 2])\n",
+    "for f in np.random.choice(vc1files, size=10000, replace=False):\n",
+    "    # load .wav data in the same way superb does.\n",
+    "    wav, sr = torchaudio.load(f) # https://github.com/s3prl/s3prl/blob/main/s3prl/downstream/voxceleb1/dataset.py#L106\n",
+    "    # pad in the same way we do in byol_a.py.\n",
+    "    wav = torch.nn.functional.pad(wav, (0, 128000))[..., :128000]\n",
+    "    # convert it to a log-mel spectrogram as a batch of single file.\n",
+    "    lms = to_logmelspec(wav[None, ...])\n",
+    "    runnorm(lms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(tensor([[[-8.9218]]]), tensor([[[4.9206]]]))"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "runnorm.ema_mean(), runnorm.ema_var().sqrt()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "s3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "b769e84a12b6ba8ed9f2d135c68967e35d1323e05994835c25f905c90cf3b906"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi, let me make a request to fix the BYOL-A implementation. We made the followings:

1. Fixed the usage regarding the calculation of normalization statistics.

It is now required to calculate the normalization statistics beforehand.

    python run_downstream.py -m train -n byola_calcnorm_vc1 -u byol_a_calcnorm -d voxceleb1 -k ./AudioNTT2020-BYOLA-64x96d2048.pth

This will output:

    ** Running Norm has finished updates over 10000 times, using the following stats from now on. ***
    mean,std=-8.907230377197266,4.892485618591309
    *** Please use these statistics in your model. EXIT... ***

Then we can train and test.

    python run_downstream.py -m train -n my_byol_a_vc1_1 -u byol_a -d voxceleb1 -o "config.optimizer.lr=1e-3" -k ./AudioNTT2020-BYOLA-64x96d2048.pth,-8.907230377197266,4.892485618591309
    python run_downstream.py -m evaluate -e result/downstream/my_byol_a_vc1_1/dev-best.ckpt

2. Enhanced to collect features from all the layers.

Now the model collects features from all 5 layers (although it doesn't push the performance much).

And some small fixes. Thanks!