### PR TITLE
Remove unlink block

### DIFF
--- a/s3prl/util/download.py
+++ b/s3prl/util/download.py
@@ -179,10 +179,6 @@ def _download(filepath: Path, url, refresh: bool, new_enough_secs: float = 2.0):
                 _download_url_to_file_requests(url, filepath)
 
     logger.info(f"Using URL's local file: {filepath}")
-    try:
-        lock_file.unlink()
-    except FileNotFoundError:
-        pass
 
 
 def _urls_to_filepaths(*args, refresh=False, download: bool = True):


### PR DESCRIPTION
Issue: 

#468

Solution:

Just removing `lock_file.unlink()`

In my understanding, in principle, it's impossible to remove a lock file in the process using the lock file. The try-exception block doesn't make sense  because this error comes from https://github.com/s3prl/s3prl/blob/7a2a265d998fadbd0881fc28e2c7a192e0587a08/s3prl/util/download.py#L172

https://github.com/tox-dev/py-filelock/blob/66b2d49720a215c6c03bd5ab1a840defaa00436a/src/filelock/_unix.py#L35

The following explains why a lock file can't be removed:

```
Process1: lock -> release ->  removed lockfile ->
Process2:                 -> lock  (failed because the lock file is removed when opening the lockfile)
```

That means the operation of os.open with os.O_RDWR | os.O_CREAT | os.O_TRUNC is not atomic.
