### PR TITLE
Change return_complex=True for torch.stft arguments and add torchaudi=0.13.1, 2.0.2, 2.1.0 in CI settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: [3.8]
-        torchaudio-version: [0.8.1, 0.9.1, 0.10.2, 0.11.0, 0.12.1]
+        torchaudio-version: [0.8.1, 0.9.1, 0.10.2, 0.11.0, 0.12.1, 0.13.1, 2.0.2, 2.1.0]
         include:
           - os: ubuntu-20.04
             python-version: 3.7

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We support the following environments. The test cases are ran with **[tox](./tox
 | --- | --- |
 | os  | `ubuntu-18.04`, `ubuntu-20.04` |
 | python | `3.7`, `3.8`, `3.9`, `3.10` |
-| pytorch | `1.8.1`, `1.9.1`, `1.10.2`, `1.11.0`, `1.12.1` |
+| pytorch | `1.8.1`, `1.9.1`, `1.10.2`, `1.11.0`, `1.12.1` , `1.13.1` , `2.0.1` , `2.1.0` |
 
 ## Change Log
 
@@ -93,7 +93,7 @@ Below is an **intuitive illustration** on how this toolkit may help you:
 <img src="https://raw.githubusercontent.com/s3prl/s3prl/main/file/S3PRL-interface.png" width="900"/>
 \
 \
-Feel free to use or modify our toolkit in your research. Here is a [list of papers using our toolkit](#used-by). Any question, bug report or improvement suggestion is welcome through [opening up a new issue](https://github.com/s3prl/s3prl/issues). 
+Feel free to use or modify our toolkit in your research. Here is a [list of papers using our toolkit](#used-by). Any question, bug report or improvement suggestion is welcome through [opening up a new issue](https://github.com/s3prl/s3prl/issues).
 
 If you find this toolkit helpful to your research, please do consider citing [our papers](#citation), thanks!
 
@@ -200,7 +200,7 @@ The majority of S3PRL Toolkit is licensed under the Apache License version 2.0, 
 + [Adversarial Defense for Automatic Speaker Verification by Cascaded Self-Supervised Learning Models (Wu et al., 2021)](https://arxiv.org/abs/2102.07047)
   ```
   @misc{asv_ssl,
-      title={Adversarial defense for automatic speaker verification by cascaded self-supervised learning models}, 
+      title={Adversarial defense for automatic speaker verification by cascaded self-supervised learning models},
       author={Haibin Wu and Xu Li and Andy T. Liu and Zhiyong Wu and Helen Meng and Hung-yi Lee},
       year={2021},
       eprint={2102.07047},
@@ -213,7 +213,7 @@ The majority of S3PRL Toolkit is licensed under the Apache License version 2.0, 
 + [S2VC: A Framework for Any-to-Any Voice Conversion with Self-Supervised Pretrained Representations (Lin et al., 2021)](https://arxiv.org/abs/2104.02901)
   ```
   @misc{s2vc,
-        title={S2VC: A Framework for Any-to-Any Voice Conversion with Self-Supervised Pretrained Representations}, 
+        title={S2VC: A Framework for Any-to-Any Voice Conversion with Self-Supervised Pretrained Representations},
         author={Jheng-hao Lin and Yist Y. Lin and Chung-Ming Chien and Hung-yi Lee},
         year={2021},
         eprint={2104.02901},
@@ -227,7 +227,7 @@ The majority of S3PRL Toolkit is licensed under the Apache License version 2.0, 
 + [SUPERB: Speech processing Universal PERformance Benchmark (Yang et al., 2021)](https://arxiv.org/abs/2105.01051)
   ```
   @misc{superb,
-        title={SUPERB: Speech processing Universal PERformance Benchmark}, 
+        title={SUPERB: Speech processing Universal PERformance Benchmark},
         author={Shu-wen Yang and Po-Han Chi and Yung-Sung Chuang and Cheng-I Jeff Lai and Kushal Lakhotia and Yist Y. Lin and Andy T. Liu and Jiatong Shi and Xuankai Chang and Guan-Ting Lin and Tzu-Hsien Huang and Wei-Cheng Tseng and Ko-tik Lee and Da-Rong Liu and Zili Huang and Shuyan Dong and Shang-Wen Li and Shinji Watanabe and Abdelrahman Mohamed and Hung-yi Lee},
         year={2021},
         eprint={2105.01051},
@@ -239,7 +239,7 @@ The majority of S3PRL Toolkit is licensed under the Apache License version 2.0, 
 + [Utilizing Self-supervised Representations for MOS Prediction (Tseng et al., 2021)](https://arxiv.org/abs/2104.03017)
   ```
   @misc{ssr_mos,
-      title={Utilizing Self-supervised Representations for MOS Prediction}, 
+      title={Utilizing Self-supervised Representations for MOS Prediction},
       author={Wei-Cheng Tseng and Chien-yu Huang and Wei-Tsung Kao and Yist Y. Lin and Hung-yi Lee},
       year={2021},
       eprint={2104.03017},

--- a/s3prl/upstream/baseline/preprocessor.py
+++ b/s3prl/upstream/baseline/preprocessor.py
@@ -94,6 +94,7 @@ class OnlinePreprocessor(torch.nn.Module):
             "pad_mode": "reflect",
             "normalized": False,
             "onesided": True,
+            "return_complex": True,
         }
         # stft_args: same default values as torchaudio.transforms.Spectrogram & librosa.core.spectrum._spectrogram
         self._stft = partial(torch.stft, **self._win_args, **self._stft_args)
@@ -179,6 +180,7 @@ class OnlinePreprocessor(torch.nn.Module):
         wav = wavs.unsqueeze(2)
         shape = wavs.size()
         complx = self._stft(wavs.reshape(-1, shape[-1]), window=self._window)
+        complx = torch.view_as_real(complx)
         complx = complx.reshape(shape[:-1] + complx.shape[-3:])
         # complx: (*, channel_size, feat_dim, max_len, 2)
         linear, phase = self._magphase(complx)

--- a/s3prl/upstream/passt/hear21passt/models/preprocess.py
+++ b/s3prl/upstream/passt/hear21passt/models/preprocess.py
@@ -77,7 +77,9 @@ class AugmentMelSTFT(nn.Module):
             center=True,
             normalized=False,
             window=self.window,
+            return_complex=True,
         )
+        x = torch.view_as_real(x)
         x = (x**2).sum(dim=-1)  # power mag
         fmin = self.fmin + torch.randint(self.fmin_aug_range, (1,)).item()
         fmax = (

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = all_others-deps_all-py38-{audio0.8.1, audio0.9.1, audio0.10.2, audio0.11.0, audio0.12.1},
+envlist = all_others-deps_all-py38-{audio0.8.1, audio0.9.1, audio0.10.2, audio0.11.0, audio0.12.1, audio0.13.1, audio2.0.2, audio2.1.0},
     all_others-deps_all-py37-audio0.11.0,
     all_others-deps_all-py39-audio0.8.1,
     all_others-deps_all-py310-audio0.11.0,
-    common_upstream-py38-{audio0.8.1, audio0.9.1, audio0.10.2, audio0.11.0, audio0.12.1},
+    common_upstream-py38-{audio0.8.1, audio0.9.1, audio0.10.2, audio0.11.0, audio0.12.1, audio0.13.1, audio2.0.2, audio2.1.0},
     common_upstream-py37-audio0.11.0,
     common_upstream-py39-audio0.8.1,
     common_upstream-py310-audio0.11.0,
@@ -24,6 +24,9 @@ commands =
     audio0.10.2: {envpython} -m pip install torchaudio==0.10.2
     audio0.11.0: {envpython} -m pip install torchaudio==0.11.0
     audio0.12.1: {envpython} -m pip install torchaudio==0.12.1
+    audio0.13.1: {envpython} -m pip install torchaudio==0.13.1
+    audio2.0.2: {envpython} -m pip install torchaudio==2.0.2
+    audio2.1.0: {envpython} -m pip install torchaudio==2.1.0
 
     # test import s3prl before installing dependencies for testing
     {envpython} -c "import s3prl; from s3prl.nn import S3PRLUpstream;"


### PR DESCRIPTION
I changed  the return_complex arguments for torch.stft to True because return_complex is required for torch>=2.0 and return_complex=False is deprecated.

https://pytorch.org/docs/stable/generated/torch.stft.html

I also added torchaudi=0.13.1, 2.0.2, 2.1.0 in CI settings(, but this change seems not to be tested in the current CI).

#475 