### PR TITLE
Different upstream and downstream learning rates

### DIFF
--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -231,7 +231,7 @@ class Runner():
         for entry in self.all_entries:
             if entry.trainable:
                 entry.model.train()
-                trainable_models.append(entry.model)
+                trainable_models.append((entry.name, entry.model))
                 trainable_paras += list(entry.model.parameters())
             else:
                 entry.model.eval()


### PR DESCRIPTION
Implemented support for different upstream learning rates as raised in a [feature request](https://github.com/s3prl/s3prl/issues/521).

Use instructions:
Simply add another `upstream_lr` parameter to the optimiser settings, like this:
```
optimizer:
  lr: 3.e-4
  upstream_lr: 1.e-5
  [other settings]
```
The upstream training only happens if the code is run with the `--upstream-trainable` (or `-f`) flag.