### PR TITLE
typo issue fixed in Update expert.py

### DIFF
--- a/s3prl/upstream/espnet_hubert/expert.py
+++ b/s3prl/upstream/espnet_hubert/expert.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 try:
     from espnet2.tasks.hubert import HubertTask
 except ModuleNotFoundError:
-    HuBERTTask = None
+    HubertTask = None
     logger.warning("ESPnet is not installed, cannot use espnet_hubert upstream")
 
 


### PR DESCRIPTION
typo issue in Update expert.py. becuase of that, It missed the Assertion of  `"ESPnet is not installed, run external_tools/install_espnet.sh to install"`