### PR TITLE
Fix path splitting on Windows (VoxCeleb1)

### DIFF
--- a/s3prl/downstream/voxceleb1/dataset.py
+++ b/s3prl/downstream/voxceleb1/dataset.py
@@ -24,7 +24,7 @@ class SpeakerClassifiDataset(Dataset):
 
         self.root = file_path
         self.speaker_num = 1251
-        self.meta_data =meta_data
+        self.meta_data = meta_data
         self.max_timestep = max_timestep
         self.usage_list = open(self.meta_data, "r").readlines()
 
@@ -48,7 +48,7 @@ class SpeakerClassifiDataset(Dataset):
 
         y = []
         for path in train_path_list:
-            id_string = path.split("/")[-3]
+            id_string = path.split(os.path.sep)[-3]
             y.append(int(id_string[2:]) - 10001)
 
         return y


### PR DESCRIPTION
Hello s3prl maintainers. Thank you for having a nice organizational structure to your repository! I'm sorry for not following the usual create issue -> draft PR -> PR cycle because this is quite a trivial change.

In `downstream/voxceleb1/dataset.py` there is an error that occurs on Windows systems in these lines of code:
```py
    # file_path/id0001/asfsafs/xxx.wav
    def build_label(self, train_path_list):

        y = []
        for path in train_path_list:
            id_string = path.split("/")[-3]
            y.append(int(id_string[2:]) - 10001)

        return y
```

I made a simple change to choose the right separator based on the platform using `os.path.sep`
```py
    # file_path/id0001/asfsafs/xxx.wav
    def build_label(self, train_path_list):

        y = []
        for path in train_path_list:
            id_string = path.split(os.path.sep)[-3]
            y.append(int(id_string[2:]) - 10001)

        return y
```

which fixed my problem.