### PR TITLE
Fix issues in python3.11

### DIFF
--- a/s3prl/upstream/roberta/roberta_model.py
+++ b/s3prl/upstream/roberta/roberta_model.py
@@ -2318,13 +2318,13 @@ class TransformerConfig:
         },
     )
     adaptive_input: bool = False
-    encoder: EncDecBaseConfig = EncDecBaseConfig()
+    encoder: EncDecBaseConfig = field(default_factory=EncDecBaseConfig)
     # TODO should really be in the encoder config
     max_source_positions: int = field(
         default=DEFAULT_MAX_SOURCE_POSITIONS,
         metadata={"help": "Maximum input length supported by the encoder"},
     )
-    decoder: DecoderConfig = DecoderConfig()
+    decoder: DecoderConfig = field(default_factory=DecoderConfig)
     # TODO should really be in the decoder config
     max_target_positions: int = field(
         default=DEFAULT_MAX_TARGET_POSITIONS,
@@ -2396,7 +2396,7 @@ class TransformerConfig:
         default=False, metadata={"help": "perform cross+self-attention"}
     )
     # args for Training with Quantization Noise for Extreme Model Compression ({Fan*, Stock*} et al., 2020)
-    quant_noise: QuantNoiseConfig = field(default=QuantNoiseConfig())
+    quant_noise: QuantNoiseConfig = field(default_factory=QuantNoiseConfig)
     min_params_to_wrap: int = field(
         default=DEFAULT_MIN_PARAMS_TO_WRAP,
         metadata={


### PR DESCRIPTION
Fix the default config initialization to avoid mutual definition.

After testing, seems that only 3 lines are impacted for the new rule with roberta.

Refer to #522 