### PR TITLE
jiwer 4.0 will break this downstream task

### DIFF
--- a/s3prl/downstream/a2o-vc-vcc2020/requirements.txt
+++ b/s3prl/downstream/a2o-vc-vcc2020/requirements.txt
@@ -2,5 +2,5 @@ parallel-wavegan
 fastdtw
 pyworld
 pysptk
-jiwer
+jiwer<4
 resemblyzer


### PR DESCRIPTION
Due to the deprecation of `compute_measures`.