### PR TITLE
Fixed hf model loading bug

### DIFF
--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -122,7 +122,11 @@ class Runner():
             from huggingface_hub import snapshot_download
 
             print(f'[Runner] - Downloading upstream model {self.args.upstream} from the Hugging Face Hub')
-            filepath = snapshot_download(self.args.upstream, self.args.upstream_revision, use_auth_token=True)
+            filepath = snapshot_download(
+                repo_id=self.args.upstream,
+                revision=self.args.upstream_revision,
+                use_auth_token=True
+            )
             sys.path.append(filepath)
 
             dependencies = (Path(filepath) / 'requirements.txt').resolve()


### PR DESCRIPTION
Recent versions of huggingface_hub made many parameters keyword-only. The call:
```python
snapshot_download(self.args.upstream, self.args.upstream_revision, use_auth_token=True)
```

passes two positional arguments. The snapshot_download function accepts only the first positional argument (repo_id) positionally — everything else must be passed by keyword.

Therefore, this fix changes the call to snapshot_download correctly.